### PR TITLE
feat: add vercel.json for SPA routing fallback

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` with a catch-all rewrite rule to serve `index.html` for any path
- Prevents 404s on direct URL access to non-root paths, future-proofing for client-side routing

## Why
BitmapForge is a SPA. Without this, Vercel would return a 404 for any URL that isn't `/` if accessed directly (e.g. a shared deep link). This is the standard Vercel fix for SPAs.

## Test plan
- [ ] Merge and confirm Vercel deploys successfully
- [ ] Verify navigating directly to any path serves the app instead of a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)