### PR TITLE
feat: ASCII art renderer (#23)

### DIFF
--- a/src/app/components/PreviewCanvas/PreviewCanvas.jsx
+++ b/src/app/components/PreviewCanvas/PreviewCanvas.jsx
@@ -48,7 +48,9 @@ function PreviewCanvas() {
         backgroundColor: state.backgroundColor,
         animationDuration: state.animationDuration,
         fadeVariant: state.fadeVariant,
-        seed: state.seed
+        seed: state.seed,
+        charRamp: state.charRamp,
+        asciiColored: state.asciiColored
       }),
       (slice) => manager.updateEffectOptions(slice),
       { equalityFn: shallow }

--- a/src/app/components/QualitySettings/QualitySettings.jsx
+++ b/src/app/components/QualitySettings/QualitySettings.jsx
@@ -3,6 +3,7 @@ import { useProjectStore } from '../../store/useProjectStore.js'
 import { BTN } from '../../styles/buttonStyles.js'
 import { InfoTooltip } from '../ui/InfoTooltip.jsx'
 import { RENDERER_LABELS } from '../../../engine/renderers/index.js'
+import { CHAR_RAMP_LABELS } from '../../../engine/renderers/AsciiRenderer.js'
 
 function QualitySettings() {
   const pixelSize = useProjectStore((state) => state.pixelSize)
@@ -11,6 +12,10 @@ function QualitySettings() {
   const minBrightness = useProjectStore((state) => state.minBrightness)
   const renderMode = useProjectStore((state) => state.renderMode)
   const setRenderMode = useProjectStore((state) => state.setRenderMode)
+  const charRamp = useProjectStore((state) => state.charRamp)
+  const setCharRamp = useProjectStore((state) => state.setCharRamp)
+  const asciiColored = useProjectStore((state) => state.asciiColored)
+  const setAsciiColored = useProjectStore((state) => state.setAsciiColored)
   const backgroundColor = useProjectStore((state) => state.backgroundColor)
   const seed = useProjectStore((state) => state.seed)
   const setPixelSize = useProjectStore((state) => state.setPixelSize)
@@ -21,15 +26,93 @@ function QualitySettings() {
   const randomizeSeed = useProjectStore((state) => state.randomizeSeed)
   const setSeed = useProjectStore((state) => state.setSeed)
 
-  // Finding 15: track details open state for aria-expanded
   const [advancedOpen, setAdvancedOpen] = useState(false)
+
+  const isAscii = renderMode === 'ascii'
+
+  // Shared advanced controls (background, seed, invert, min brightness)
+  const sharedAdvanced = (
+    <>
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={invert} onChange={(e) => setInvert(e.target.checked)} />
+        Invert Brightness
+        <InfoTooltip content="Swaps light and dark areas — bright areas become dark and vice versa." />
+      </label>
+
+      <label htmlFor="quality-min-brightness" className="flex items-center text-sm">
+        Min Brightness: {minBrightness.toFixed(2)}
+        <InfoTooltip content="Pixels below this luminance threshold are treated as fully dark and not drawn." />
+      </label>
+      <input
+        id="quality-min-brightness"
+        type="range"
+        min="0.01"
+        max="0.5"
+        step="0.01"
+        value={minBrightness}
+        onChange={(event) => setMinBrightness(Number(event.target.value))}
+        className="w-full"
+      />
+
+      <div className="flex items-center justify-between">
+        <span className="flex items-center text-sm">
+          Particle seed
+          <InfoTooltip content="Controls the scatter pattern during fade animations. Different seeds = different visual patterns." />
+        </span>
+        <div className="flex items-center gap-1">
+          <span className="font-mono text-xs text-zinc-400">
+            {seed === null ? 'auto' : `#${seed.toString(16).padStart(8, '0')}`}
+          </span>
+          <button
+            type="button"
+            onClick={randomizeSeed}
+            className="rounded bg-zinc-700 px-2 py-0.5 text-xs hover:bg-zinc-600"
+            title="Generate new random seed"
+          >
+            ↻
+          </button>
+          {seed !== null && (
+            <button
+              type="button"
+              onClick={() => setSeed(null)}
+              className="rounded bg-zinc-700 px-2 py-0.5 text-xs hover:bg-zinc-600"
+              title="Reset to auto (deterministic hash)"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      </div>
+
+      <label className="block text-sm">
+        <span className="flex items-center">
+          Background
+          <InfoTooltip content="Canvas background color. Choose Transparent for PNG/GIF exports with alpha." />
+        </span>
+        <div className="mt-1 flex items-center gap-2">
+          <button
+            type="button"
+            className={`${BTN.base} ${BTN.secondary}`}
+            onClick={() => setBackgroundColor('transparent')}
+          >
+            Transparent
+          </button>
+          <input
+            type="color"
+            value={backgroundColor === 'transparent' ? '#000000' : backgroundColor}
+            onChange={(event) => setBackgroundColor(event.target.value)}
+          />
+        </div>
+      </label>
+    </>
+  )
 
   return (
     <section className="space-y-3">
       <label className="block text-sm">
         <span className="flex items-center">
           Render Mode
-          <InfoTooltip content="Bitmap: dithered pixel grid with configurable algorithms. Pixel Art: clean squares, nearest-palette-color, no dithering." />
+          <InfoTooltip content="Bitmap: dithered pixel grid. Pixel Art: clean squares, no dithering. ASCII: characters mapped from brightness." />
         </span>
         <select
           className="mt-1 w-full rounded bg-zinc-800 p-1"
@@ -44,122 +127,108 @@ function QualitySettings() {
         </select>
       </label>
 
-      <label htmlFor="quality-pixel-size" className="flex items-center text-sm">
-        Pixel Size: {pixelSize}
-        <InfoTooltip content="Grid resolution. Smaller = more detail, larger = blockier/more pixelated." />
-      </label>
-      <input
-        id="quality-pixel-size"
-        type="range"
-        min="1"
-        max="20"
-        value={pixelSize}
-        onChange={(event) => setPixelSize(Number(event.target.value))}
-        className="w-full"
-      />
-
-      {/* Finding 15: controlled details with aria-expanded */}
-      <details
-        className="rounded border border-zinc-700 p-2"
-        open={advancedOpen}
-        onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
-      >
-        <summary className="cursor-pointer text-sm" aria-expanded={advancedOpen}>
-          Advanced
-        </summary>
-        <div className="mt-2 space-y-3">
+      {isAscii ? (
+        /* ── ASCII mode controls ─────────────────────────── */
+        <>
           <label className="block text-sm">
             <span className="flex items-center">
-              Dither Type
-              <InfoTooltip content="Algorithm for shading. Bayer = ordered grid pattern. Variable Dot = halftone circles. Floyd-Steinberg / Atkinson = error-diffusion (smoother gradients, slower)." />
+              Character Ramp
+              <InfoTooltip content="The set of characters used to represent brightness levels. Classic is the standard ASCII art ramp, Blocks uses Unicode fill chars, Dense has 70 levels, Minimal is high-contrast." />
             </span>
             <select
               className="mt-1 w-full rounded bg-zinc-800 p-1"
-              value={ditherType}
-              onChange={(event) => setDitherType(event.target.value)}
+              value={charRamp}
+              onChange={(e) => setCharRamp(e.target.value)}
             >
-              <option value="bayer4x4">Bayer 4×4</option>
-              <option value="bayer8x8">Bayer 8×8</option>
-              <option value="variableDot">Variable Dot</option>
-              <option value="floydSteinberg">Floyd-Steinberg</option>
-              <option value="atkinson">Atkinson</option>
+              {Object.entries(CHAR_RAMP_LABELS).map(([key, label]) => (
+                <option key={key} value={key}>
+                  {label}
+                </option>
+              ))}
             </select>
           </label>
 
           <label className="flex items-center gap-2 text-sm">
-            <input type="checkbox" checked={invert} onChange={(e) => setInvert(e.target.checked)} />
-            Invert Brightness
-            <InfoTooltip content="Swaps light and dark areas — bright areas become dark and vice versa." />
+            <input type="checkbox" checked={asciiColored} onChange={(e) => setAsciiColored(e.target.checked)} />
+            Colored Mode
+            <InfoTooltip content="When off, all characters use the brightest palette color (classic terminal look). When on, each character is tinted by its brightness zone using the full palette." />
           </label>
 
-          <label htmlFor="quality-min-brightness" className="flex items-center text-sm">
-            Min Brightness: {minBrightness.toFixed(2)}
-            <InfoTooltip content="Pixels below this luminance threshold are treated as fully dark and not drawn." />
+          <label htmlFor="quality-char-size" className="flex items-center text-sm">
+            Character Size: {pixelSize}px
+            <InfoTooltip content="Cell size for each character. Smaller = more characters, denser output. Larger = more readable individual chars. Keep above 8px for legible text." />
           </label>
           <input
-            id="quality-min-brightness"
+            id="quality-char-size"
             type="range"
-            min="0.01"
-            max="0.5"
-            step="0.01"
-            value={minBrightness}
-            onChange={(event) => setMinBrightness(Number(event.target.value))}
+            min="8"
+            max="32"
+            value={pixelSize}
+            onChange={(event) => setPixelSize(Number(event.target.value))}
             className="w-full"
           />
 
-          <div className="flex items-center justify-between">
-            <span className="flex items-center text-sm">
-              Particle seed
-              <InfoTooltip content="Controls the scatter pattern during fade animations. Different seeds = different visual patterns. Null uses a classic deterministic pattern." />
-            </span>
-            <div className="flex items-center gap-1">
-              <span className="font-mono text-xs text-zinc-400">
-                {seed === null ? 'auto' : `#${seed.toString(16).padStart(8, '0')}`}
-              </span>
-              <button
-                type="button"
-                onClick={randomizeSeed}
-                className="rounded bg-zinc-700 px-2 py-0.5 text-xs hover:bg-zinc-600"
-                title="Generate new random seed"
-              >
-                ↻
-              </button>
-              {seed !== null && (
-                <button
-                  type="button"
-                  onClick={() => setSeed(null)}
-                  className="rounded bg-zinc-700 px-2 py-0.5 text-xs hover:bg-zinc-600"
-                  title="Reset to auto (deterministic hash)"
-                >
-                  ✕
-                </button>
-              )}
-            </div>
-          </div>
-
-          <label className="block text-sm">
-            <span className="flex items-center">
-              Background
-              <InfoTooltip content="Canvas background color. Choose Transparent for PNG/GIF exports with alpha." />
-            </span>
-            <div className="mt-1 flex items-center gap-2">
-              {/* Finding 22: standardized button style */}
-              <button
-                type="button"
-                className={`${BTN.base} ${BTN.secondary}`}
-                onClick={() => setBackgroundColor('transparent')}
-              >
-                Transparent
-              </button>
-              <input
-                type="color"
-                value={backgroundColor === 'transparent' ? '#000000' : backgroundColor}
-                onChange={(event) => setBackgroundColor(event.target.value)}
-              />
-            </div>
+          <details
+            className="rounded border border-zinc-700 p-2"
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+          >
+            <summary className="cursor-pointer text-sm" aria-expanded={advancedOpen}>
+              Advanced
+            </summary>
+            <div className="mt-2 space-y-3">{sharedAdvanced}</div>
+          </details>
+        </>
+      ) : (
+        /* ── Bitmap / Pixel Art mode controls ───────────── */
+        <>
+          <label htmlFor="quality-pixel-size" className="flex items-center text-sm">
+            Pixel Size: {pixelSize}
+            <InfoTooltip content="Grid resolution. Smaller = more detail, larger = blockier/more pixelated." />
           </label>
-        </div>
-      </details>
+          <input
+            id="quality-pixel-size"
+            type="range"
+            min="1"
+            max="20"
+            value={pixelSize}
+            onChange={(event) => setPixelSize(Number(event.target.value))}
+            className="w-full"
+          />
+
+          <details
+            className="rounded border border-zinc-700 p-2"
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+          >
+            <summary className="cursor-pointer text-sm" aria-expanded={advancedOpen}>
+              Advanced
+            </summary>
+            <div className="mt-2 space-y-3">
+              {renderMode === 'bitmap' && (
+                <label className="block text-sm">
+                  <span className="flex items-center">
+                    Dither Type
+                    <InfoTooltip content="Algorithm for shading. Bayer = ordered grid pattern. Variable Dot = halftone circles. Floyd-Steinberg / Atkinson = error-diffusion (smoother gradients, slower)." />
+                  </span>
+                  <select
+                    className="mt-1 w-full rounded bg-zinc-800 p-1"
+                    value={ditherType}
+                    onChange={(event) => setDitherType(event.target.value)}
+                  >
+                    <option value="bayer4x4">Bayer 4×4</option>
+                    <option value="bayer8x8">Bayer 8×8</option>
+                    <option value="variableDot">Variable Dot</option>
+                    <option value="floydSteinberg">Floyd-Steinberg</option>
+                    <option value="atkinson">Atkinson</option>
+                  </select>
+                </label>
+              )}
+              {sharedAdvanced}
+            </div>
+          </details>
+        </>
+      )}
     </section>
   )
 }

--- a/src/app/store/useProjectStore.js
+++ b/src/app/store/useProjectStore.js
@@ -29,8 +29,11 @@ const DEFAULT_STATE = {
   // null = use legacy deterministic hash for particle scatter (backward compatible)
   // number = seeded PRNG — enables reproducible, user-controllable scatter patterns
   seed: null,
-  // Rendering mode ('bitmap' | 'pixelArt') — controls active renderer in BitmapEffect
+  // Rendering mode ('bitmap' | 'pixelArt' | 'ascii') — controls active renderer in BitmapEffect
   renderMode: 'bitmap',
+  // ASCII renderer settings
+  charRamp: 'classic', // key into CHAR_RAMPS: 'classic' | 'blocks' | 'dense' | 'minimal'
+  asciiColored: false, // false = monochrome (brightest palette color), true = full-palette mapping
   // Input source type — which tab is active in the input panel
   inputType: 'model', // 'model' | 'shape' | 'text' | 'image'
   // Shape primitive settings
@@ -140,7 +143,16 @@ const useProjectStore = create(
       resetBaseRotation: () => set({ baseRotation: { x: 0, y: 0, z: 0 } }),
       setSeed: (seed) => set({ seed }),
       randomizeSeed: () => set({ seed: randomSeed() }),
-      setRenderMode: (renderMode) => set({ renderMode }),
+      setRenderMode: (renderMode) => {
+        const update = { renderMode }
+        // ASCII chars below 8px are unreadable — nudge pixelSize to a legible minimum
+        if (renderMode === 'ascii' && get().pixelSize < 8) {
+          update.pixelSize = 10
+        }
+        set(update)
+      },
+      setCharRamp: (charRamp) => set({ charRamp }),
+      setAsciiColored: (asciiColored) => set({ asciiColored }),
       setInputType: (inputType) => set({ inputType }),
       setShapeType: (shapeType) => set({ shapeType, shapeParams: {} }),
       setShapeParam: (key, value) => set((state) => ({ shapeParams: { ...state.shapeParams, [key]: value } })),

--- a/src/app/utils/codeExport.test.js
+++ b/src/app/utils/codeExport.test.js
@@ -100,7 +100,7 @@ describe('buildCodeZip — engine sources', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getCodeZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(20)
+    expect(engineFiles).toHaveLength(21)
   })
 
   it('ZIP contains engine/SceneManager.js', async () => {

--- a/src/app/utils/engineSources.js
+++ b/src/app/utils/engineSources.js
@@ -14,6 +14,7 @@ import fadeVariantsIndexSrc from '../../engine/effects/fadeVariants/index.js?raw
 import BaseRendererSrc from '../../engine/renderers/BaseRenderer.js?raw'
 import BitmapRendererSrc from '../../engine/renderers/BitmapRenderer.js?raw'
 import PixelArtRendererSrc from '../../engine/renderers/PixelArtRenderer.js?raw'
+import AsciiRendererSrc from '../../engine/renderers/AsciiRenderer.js?raw'
 import renderersIndexSrc from '../../engine/renderers/index.js?raw'
 import modelLoaderSrc from '../../engine/loaders/modelLoader.js?raw'
 import AnimationEngineSrc from '../../engine/animation/AnimationEngine.js?raw'
@@ -43,6 +44,7 @@ const ENGINE_SOURCES = [
   { path: 'engine/renderers/BaseRenderer.js', content: BaseRendererSrc },
   { path: 'engine/renderers/BitmapRenderer.js', content: BitmapRendererSrc },
   { path: 'engine/renderers/PixelArtRenderer.js', content: PixelArtRendererSrc },
+  { path: 'engine/renderers/AsciiRenderer.js', content: AsciiRendererSrc },
   { path: 'engine/renderers/index.js', content: renderersIndexSrc },
   { path: 'engine/loaders/modelLoader.js', content: modelLoaderSrc },
   { path: 'engine/animation/AnimationEngine.js', content: AnimationEngineSrc },

--- a/src/app/utils/engineSources.test.js
+++ b/src/app/utils/engineSources.test.js
@@ -17,6 +17,7 @@ const REQUIRED_PATHS = [
   'engine/renderers/BaseRenderer.js',
   'engine/renderers/BitmapRenderer.js',
   'engine/renderers/PixelArtRenderer.js',
+  'engine/renderers/AsciiRenderer.js',
   'engine/renderers/index.js',
   'engine/loaders/modelLoader.js',
   'engine/animation/AnimationEngine.js',
@@ -66,6 +67,7 @@ describe('ENGINE_SOURCES', () => {
       'engine/renderers/BaseRenderer.js',
       'engine/renderers/BitmapRenderer.js',
       'engine/renderers/PixelArtRenderer.js',
+      'engine/renderers/AsciiRenderer.js',
       'engine/renderers/index.js'
     ]
     const paths = new Set(ENGINE_SOURCES.map((e) => e.path))

--- a/src/app/utils/reactComponentExport.test.js
+++ b/src/app/utils/reactComponentExport.test.js
@@ -63,7 +63,7 @@ describe('buildReactComponent — ZIP structure', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(20)
+    expect(engineFiles).toHaveLength(21)
   })
 
   it('uses custom component name for folder', async () => {

--- a/src/app/utils/webComponentExport.test.js
+++ b/src/app/utils/webComponentExport.test.js
@@ -58,7 +58,7 @@ describe('buildWebComponent — ZIP structure', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(20)
+    expect(engineFiles).toHaveLength(21)
   })
 
   it('uses custom element name for folder and file', async () => {

--- a/src/engine/animation/AnimationEngine.js
+++ b/src/engine/animation/AnimationEngine.js
@@ -176,14 +176,24 @@ class AnimationEngine {
     if (currentPhase === 'fadeIn' && effect.isAnimationComplete()) {
       effect.startAnimation('show')
       this.phaseStartTime = now
+      // Do NOT call applyEffects here. The transition frame must render at the same
+      // rotation the particles were computed from — any increment would cause a visible
+      // tilt as the static render snaps to a different pose than the particle positions.
+      // Rotation begins on the next frame when the show branch runs normally.
     } else if (currentPhase === 'show') {
       this.applyEffects(modelGroup, deltaSeconds)
       this._applyResetTransitions(modelGroup, deltaSeconds)
       if (now - this.phaseStartTime >= this.showPhaseDuration) {
         effect.startAnimation('fadeOut')
       }
-    } else if (currentPhase === 'fadeOut' && effect.isAnimationComplete()) {
-      effect.startAnimation('fadeIn')
+    } else if (currentPhase === 'fadeOut') {
+      // Continue rotating during fade-out — particles are 2D snapshots that fade
+      // independently of the 3D model, so rotation here is visually seamless.
+      this.applyEffects(modelGroup, deltaSeconds)
+      this._applyResetTransitions(modelGroup, deltaSeconds)
+      if (effect.isAnimationComplete()) {
+        effect.startAnimation('fadeIn')
+      }
     }
   }
 
@@ -222,13 +232,12 @@ class AnimationEngine {
       let showTs = ts // seconds elapsed within the show phase
       if (this.useFadeInOut) {
         const fadeDurS = this.animationDuration / 1000
-        const showDurS = this.showPhaseDuration / 1000
         if (ts < fadeDurS) {
           showTs = 0 // fade-in: model stationary at rotation 0
-        } else if (ts < fadeDurS + showDurS) {
-          showTs = ts - fadeDurS // show: accumulate from show start
         } else {
-          showTs = showDurS // fade-out: frozen at end-of-show rotation
+          // Both show and fade-out: rotation runs continuously from show start.
+          // fade-out keeps the model spinning (matches live animation behaviour).
+          showTs = ts - fadeDurS
         }
       }
 

--- a/src/engine/renderers/AsciiRenderer.js
+++ b/src/engine/renderers/AsciiRenderer.js
@@ -1,0 +1,237 @@
+import { BaseRenderer } from './BaseRenderer.js'
+
+/**
+ * Named character ramp presets — ordered darkest-to-brightest (lowest to highest ink density).
+ * The first character (typically space) maps to near-black areas and is skipped (background shows).
+ */
+const CHAR_RAMPS = {
+  classic: ' .:-=+*#%@',
+  blocks: ' ░▒▓█',
+  dense: ' .\'`^",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$',
+  minimal: ' .+#'
+}
+
+const CHAR_RAMP_LABELS = {
+  classic: 'Classic ( .:-=+*#%@ )',
+  blocks: 'Blocks (░▒▓█)',
+  dense: 'Dense (70 chars)',
+  minimal: 'Minimal ( .+# )'
+}
+
+const MONOSPACE_FONT = 'Menlo, Monaco, Consolas, monospace'
+
+/**
+ * AsciiRenderer — maps brightness to characters drawn on a background fill.
+ *
+ * Monochrome mode (asciiColored: false): all characters use getColor(1) — the brightest
+ * palette color — giving classic terminal ASCII art (e.g., green-on-black).
+ * Colored mode (asciiColored: true): each character's color maps from its brightness
+ * through the full palette, producing full-color ASCII art.
+ */
+class AsciiRenderer extends BaseRenderer {
+  constructor(options = {}) {
+    super({
+      pixelSize: 3,
+      minBrightness: 0.05,
+      invert: false,
+      backgroundColor: '#0a0a0a',
+      charRamp: 'classic',
+      asciiColored: false,
+      ...options
+    })
+    this._bitmapCanvas = document.createElement('canvas')
+    this._bitmapCanvas.style.display = 'block'
+    this._bitmapCtx = this._bitmapCanvas.getContext('2d')
+
+    // Derived state — recomputed when dirty
+    this._dirty = true
+    this._rampChars = []
+    this._rampLen = 0
+    this._fontStr = ''
+    this._cellW = 0
+    this._cellH = 0
+    this._xOffset = 0 // horizontal centering offset within cell
+    this._lastFill = null
+    this._lastGridW = 0
+    this._lastGridH = 0
+  }
+
+  get canvas() {
+    return this._bitmapCanvas
+  }
+
+  init(width, height) {
+    this.setSize(width, height)
+  }
+
+  setSize(width, height) {
+    if (this._bitmapCanvas) {
+      this._bitmapCanvas.width = Math.max(1, Math.floor(width))
+      this._bitmapCanvas.height = Math.max(1, Math.floor(height))
+      this._dirty = true
+    }
+  }
+
+  updateOptions(options) {
+    // Capture old values BEFORE super mutates this.options via Object.assign
+    const prevCharRamp = this.options.charRamp
+    const prevPixelSize = this.options.pixelSize
+    super.updateOptions(options)
+    if (
+      (options.charRamp !== undefined && options.charRamp !== prevCharRamp) ||
+      (options.pixelSize !== undefined && options.pixelSize !== prevPixelSize)
+    ) {
+      this._dirty = true
+    }
+  }
+
+  beginFrame(backgroundColor) {
+    if (!this._bitmapCtx) return
+    if (backgroundColor === 'transparent') {
+      this._bitmapCtx.clearRect(0, 0, this._bitmapCanvas.width, this._bitmapCanvas.height)
+    } else {
+      this._bitmapCtx.fillStyle = backgroundColor
+      this._bitmapCtx.fillRect(0, 0, this._bitmapCanvas.width, this._bitmapCanvas.height)
+    }
+    this._lastFill = null
+  }
+
+  endFrame() {}
+
+  shouldDraw(brightness) {
+    return brightness > this.options.minBrightness
+  }
+
+  /**
+   * Recompute derived state: ramp chars, font string, cell dimensions, glyph centering offset.
+   * Called lazily before the first draw each frame.
+   */
+  _prepare(gridW, gridH) {
+    const rampStr = CHAR_RAMPS[this.options.charRamp] ?? CHAR_RAMPS.classic
+    this._rampChars = Array.from(rampStr)
+    this._rampLen = this._rampChars.length
+
+    this._cellW = this._bitmapCanvas.width / gridW
+    this._cellH = this._bitmapCanvas.height / gridH
+    const fontSize = Math.max(6, Math.floor(this._cellH))
+    this._fontStr = `${fontSize}px ${MONOSPACE_FONT}`
+
+    const ctx = this._bitmapCtx
+    ctx.font = this._fontStr
+    ctx.textBaseline = 'top'
+    ctx.textAlign = 'left'
+
+    // Measure a representative glyph to center it horizontally within the cell
+    const metrics = ctx.measureText('M')
+    this._xOffset = Math.max(0, (this._cellW - metrics.width) * 0.5)
+
+    this._lastGridW = gridW
+    this._lastGridH = gridH
+    this._dirty = false
+    this._lastFill = null
+  }
+
+  _glyphFor(brightness) {
+    const adjusted = this.options.invert ? 1 - brightness : brightness
+    const idx = Math.min(Math.round(adjusted * (this._rampLen - 1)), this._rampLen - 1)
+    const ch = this._rampChars[idx]
+    return ch === ' ' ? null : ch
+  }
+
+  /**
+   * Draw a single character during fade animations.
+   * x/y are pre-multiplied canvas coordinates (gx * pixelSize, gy * pixelSize).
+   * Snap back to cell grid to prevent jitter when pixelSize != cellSize.
+   */
+  drawPixel(x, y, brightness, color, alpha = 1) {
+    if (!this._bitmapCtx) return
+
+    // _prepare() is normally called by render(), but render() is skipped during fade
+    // animations (isAnimating = true). Lazily prepare here so particles are visible.
+    if ((this._dirty || this._cellW === 0) && this._bitmapCanvas.width > 0) {
+      const { pixelSize } = this.options
+      const gridW = Math.max(1, Math.floor(this._bitmapCanvas.width / pixelSize))
+      const gridH = Math.max(1, Math.floor(this._bitmapCanvas.height / pixelSize))
+      this._prepare(gridW, gridH)
+    }
+
+    if (this._cellW === 0 || this._cellH === 0) return
+    const ch = this._glyphFor(brightness)
+    if (!ch) return
+
+    const ctx = this._bitmapCtx
+
+    // Recover original grid coordinates from the particle's screen position.
+    // initializeParticles sets finalX = gx * pixelSize (exact integer multiple),
+    // so round(x / pixelSize) = gx exactly — no floating-point drift.
+    // Drawing at gx * cellW + xOffset matches render() precisely, preventing
+    // the left/down positional shift at the fade→static transition.
+    const { pixelSize, asciiColored, colors } = this.options
+    const gx = Math.round(x / pixelSize)
+    const gy = Math.round(y / pixelSize)
+
+    if (this._fontStr) {
+      ctx.font = this._fontStr
+      ctx.textBaseline = 'top'
+      ctx.textAlign = 'left'
+    }
+
+    const fill = asciiColored ? color : (colors?.[colors.length - 1] ?? color)
+    if (alpha < 1) ctx.globalAlpha = alpha
+    ctx.fillStyle = fill
+    ctx.fillText(ch, gx * this._cellW + this._xOffset, gy * this._cellH)
+    if (alpha < 1) ctx.globalAlpha = 1
+  }
+
+  render(imageData, gridW, gridH, getColor) {
+    if (!this._bitmapCtx || gridW === 0 || gridH === 0) return
+
+    if (this._dirty || gridW !== this._lastGridW || gridH !== this._lastGridH) {
+      this._prepare(gridW, gridH)
+    }
+
+    const { minBrightness, invert, asciiColored } = this.options
+    const ctx = this._bitmapCtx
+
+    // Ensure font is set (beginFrame may have changed context state)
+    ctx.font = this._fontStr
+    ctx.textBaseline = 'top'
+    ctx.textAlign = 'left'
+
+    for (let gy = 0; gy < gridH; gy++) {
+      for (let gx = 0; gx < gridW; gx++) {
+        const iOffset = (gy * gridW + gx) * 4
+        const r = imageData[iOffset]
+        const g = imageData[iOffset + 1]
+        const b = imageData[iOffset + 2]
+        const a = imageData[iOffset + 3]
+        if (a === 0) continue
+
+        const brightness = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+        if (brightness < minBrightness) continue
+
+        const adjusted = invert ? 1 - brightness : brightness
+        const idx = Math.min(Math.round(adjusted * (this._rampLen - 1)), this._rampLen - 1)
+        const ch = this._rampChars[idx]
+        if (ch === ' ') continue
+
+        const fill = asciiColored ? getColor(adjusted) : getColor(1)
+        if (fill !== this._lastFill) {
+          ctx.fillStyle = fill
+          this._lastFill = fill
+        }
+        ctx.fillText(ch, gx * this._cellW + this._xOffset, gy * this._cellH)
+      }
+    }
+  }
+
+  dispose() {
+    if (this._bitmapCanvas?.parentNode) {
+      this._bitmapCanvas.parentNode.removeChild(this._bitmapCanvas)
+    }
+    this._bitmapCanvas = null
+    this._bitmapCtx = null
+  }
+}
+
+export { AsciiRenderer, CHAR_RAMPS, CHAR_RAMP_LABELS }

--- a/src/engine/renderers/index.js
+++ b/src/engine/renderers/index.js
@@ -1,14 +1,17 @@
 import { BitmapRenderer } from './BitmapRenderer.js'
 import { PixelArtRenderer } from './PixelArtRenderer.js'
+import { AsciiRenderer } from './AsciiRenderer.js'
 
 const RENDERERS = {
   bitmap: BitmapRenderer,
-  pixelArt: PixelArtRenderer
+  pixelArt: PixelArtRenderer,
+  ascii: AsciiRenderer
 }
 
 const RENDERER_LABELS = {
   bitmap: 'Bitmap (Dithered)',
-  pixelArt: 'Pixel Art (Clean)'
+  pixelArt: 'Pixel Art (Clean)',
+  ascii: 'ASCII Art'
 }
 
 /**

--- a/test/integration/exportConformance.test.js
+++ b/test/integration/exportConformance.test.js
@@ -218,7 +218,7 @@ describe('React component ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(20)
+    expect(engineFiles).toHaveLength(21)
   })
 })
 
@@ -254,7 +254,7 @@ describe('Web Component ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(20)
+    expect(engineFiles).toHaveLength(21)
   })
 })
 
@@ -324,6 +324,6 @@ describe('Code ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(20)
+    expect(engineFiles).toHaveLength(21)
   })
 })


### PR DESCRIPTION
## Summary

- **New renderer**: `AsciiRenderer` with 4 character ramps — Classic (`.:-=+*#%@`), Blocks (`░▒▓█`), Dense (70 chars), Minimal (`.+#`)
- **Mode-aware UI**: `QualitySettings` splits into ASCII panel (char ramp, colored mode, char size 8–32px) and Bitmap/Pixel Art panel (pixel size 1–20px, dither type); shared Advanced section for both
- **Colored mode**: monochrome uses brightest palette color, colored maps each character's brightness through the full palette

## Bug fixes (ASCII mode)

- **Invisible fade**: `drawPixel` skipped particles because `_prepare()` was never called during `isAnimating=true`. Fixed with lazy init in `drawPixel`.
- **Positional shift left/down after fade-in**: Grid coordinate recovery used `Math.floor(x / cellW)` which drifted when `cellW > pixelSize`. Fixed: `Math.round(x / pixelSize)` recovers exact original grid index since `finalX = gx * pixelSize` exactly.
- **Color jump in monochrome mode**: `drawPixel` used brightness-mapped color; `render()` used `getColor(1)`. Fixed by using `colors[last]` in both paths.
- **Tilt on fadeIn→show transition**: `applyEffects` was called on the transition frame, rotating the model before static render — particles landed at the old pose. Fixed: no `applyEffects` on transition; rotation starts next frame.
- **Model freezing at fadeOut start**: `applyEffects` only ran in `show` branch. Fixed: added `fadeOut` branch that continues rotation.

## Engine wiring

- `charRamp` + `asciiColored` subscribed in `PreviewCanvas` → propagates via `manager.updateEffectOptions()`
- `AsciiRenderer.js` added to `ENGINE_SOURCES` (code export ZIP, React Component, Web Component)
- All engine file count tests updated: 20 → 21

## Test plan

- [x] All 270 tests pass
- [ ] Switch render mode to ASCII — character ramp changes take effect immediately
- [ ] Toggle Colored Mode on/off — no color jump between fade and static phases
- [ ] Fade in/out cycle — smooth rotation throughout, no tilt or positional shift
- [ ] Export formats (Code ZIP, React Component, Web Component) include AsciiRenderer.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)