### PR TITLE
feat: halftone renderer (#25)

### DIFF
--- a/src/app/components/PreviewCanvas/PreviewCanvas.jsx
+++ b/src/app/components/PreviewCanvas/PreviewCanvas.jsx
@@ -50,7 +50,9 @@ function PreviewCanvas() {
         fadeVariant: state.fadeVariant,
         seed: state.seed,
         charRamp: state.charRamp,
-        asciiColored: state.asciiColored
+        asciiColored: state.asciiColored,
+        halftoneDotShape: state.halftoneDotShape,
+        halftoneAngle: state.halftoneAngle
       }),
       (slice) => manager.updateEffectOptions(slice),
       { equalityFn: shallow }

--- a/src/app/components/QualitySettings/QualitySettings.jsx
+++ b/src/app/components/QualitySettings/QualitySettings.jsx
@@ -16,6 +16,10 @@ function QualitySettings() {
   const setCharRamp = useProjectStore((state) => state.setCharRamp)
   const asciiColored = useProjectStore((state) => state.asciiColored)
   const setAsciiColored = useProjectStore((state) => state.setAsciiColored)
+  const halftoneDotShape = useProjectStore((state) => state.halftoneDotShape)
+  const setHalftoneDotShape = useProjectStore((state) => state.setHalftoneDotShape)
+  const halftoneAngle = useProjectStore((state) => state.halftoneAngle)
+  const setHalftoneAngle = useProjectStore((state) => state.setHalftoneAngle)
   const backgroundColor = useProjectStore((state) => state.backgroundColor)
   const seed = useProjectStore((state) => state.seed)
   const setPixelSize = useProjectStore((state) => state.setPixelSize)
@@ -29,6 +33,7 @@ function QualitySettings() {
   const [advancedOpen, setAdvancedOpen] = useState(false)
 
   const isAscii = renderMode === 'ascii'
+  const isHalftone = renderMode === 'halftone'
 
   // Shared advanced controls (background, seed, invert, min brightness)
   const sharedAdvanced = (
@@ -112,7 +117,7 @@ function QualitySettings() {
       <label className="block text-sm">
         <span className="flex items-center">
           Render Mode
-          <InfoTooltip content="Bitmap: dithered pixel grid. Pixel Art: clean squares, no dithering. ASCII: characters mapped from brightness." />
+          <InfoTooltip content="Bitmap: dithered pixel grid. Pixel Art: clean squares, no dithering. ASCII: characters mapped from brightness. Halftone: variable-size dots, like print halftone screens." />
         </span>
         <select
           className="mt-1 w-full rounded bg-zinc-800 p-1"
@@ -127,7 +132,64 @@ function QualitySettings() {
         </select>
       </label>
 
-      {isAscii ? (
+      {isHalftone ? (
+        /* ── Halftone mode controls ──────────────────────── */
+        <>
+          <label htmlFor="quality-dot-spacing" className="flex items-center text-sm">
+            Dot Spacing: {pixelSize}px
+            <InfoTooltip content="Grid cell size for each dot. Smaller = more dots (finer screen), larger = fewer dots (coarser screen)." />
+          </label>
+          <input
+            id="quality-dot-spacing"
+            type="range"
+            min="4"
+            max="20"
+            value={pixelSize}
+            onChange={(event) => setPixelSize(Number(event.target.value))}
+            className="w-full"
+          />
+
+          <label className="block text-sm">
+            <span className="flex items-center">
+              Dot Shape
+              <InfoTooltip content="Circle: standard halftone screen dots. Diamond: rotated square dots, gives a different texture." />
+            </span>
+            <select
+              className="mt-1 w-full rounded bg-zinc-800 p-1"
+              value={halftoneDotShape}
+              onChange={(e) => setHalftoneDotShape(e.target.value)}
+            >
+              <option value="circle">Circle</option>
+              <option value="diamond">Diamond</option>
+            </select>
+          </label>
+
+          <label htmlFor="quality-halftone-angle" className="flex items-center text-sm">
+            Screen Angle: {halftoneAngle}°
+            <InfoTooltip content="Rotates the dot grid. Classic print screens use 45° for black ink to reduce moiré patterns." />
+          </label>
+          <input
+            id="quality-halftone-angle"
+            type="range"
+            min="0"
+            max="179"
+            value={halftoneAngle}
+            onChange={(event) => setHalftoneAngle(Number(event.target.value))}
+            className="w-full"
+          />
+
+          <details
+            className="rounded border border-zinc-700 p-2"
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+          >
+            <summary className="cursor-pointer text-sm" aria-expanded={advancedOpen}>
+              Advanced
+            </summary>
+            <div className="mt-2 space-y-3">{sharedAdvanced}</div>
+          </details>
+        </>
+      ) : isAscii ? (
         /* ── ASCII mode controls ─────────────────────────── */
         <>
           <label className="block text-sm">

--- a/src/app/store/useProjectStore.js
+++ b/src/app/store/useProjectStore.js
@@ -29,11 +29,14 @@ const DEFAULT_STATE = {
   // null = use legacy deterministic hash for particle scatter (backward compatible)
   // number = seeded PRNG — enables reproducible, user-controllable scatter patterns
   seed: null,
-  // Rendering mode ('bitmap' | 'pixelArt' | 'ascii') — controls active renderer in BitmapEffect
+  // Rendering mode ('bitmap' | 'pixelArt' | 'ascii' | 'halftone') — controls active renderer in BitmapEffect
   renderMode: 'bitmap',
   // ASCII renderer settings
   charRamp: 'classic', // key into CHAR_RAMPS: 'classic' | 'blocks' | 'dense' | 'minimal'
   asciiColored: false, // false = monochrome (brightest palette color), true = full-palette mapping
+  // Halftone renderer settings
+  halftoneDotShape: 'circle', // 'circle' | 'diamond'
+  halftoneAngle: 0, // degrees, normalized to [0, 180) by the renderer
   // Input source type — which tab is active in the input panel
   inputType: 'model', // 'model' | 'shape' | 'text' | 'image'
   // Shape primitive settings
@@ -153,6 +156,8 @@ const useProjectStore = create(
       },
       setCharRamp: (charRamp) => set({ charRamp }),
       setAsciiColored: (asciiColored) => set({ asciiColored }),
+      setHalftoneDotShape: (halftoneDotShape) => set({ halftoneDotShape }),
+      setHalftoneAngle: (halftoneAngle) => set({ halftoneAngle: Math.max(0, Math.min(179, halftoneAngle)) }),
       setInputType: (inputType) => set({ inputType }),
       setShapeType: (shapeType) => set({ shapeType, shapeParams: {} }),
       setShapeParam: (key, value) => set((state) => ({ shapeParams: { ...state.shapeParams, [key]: value } })),

--- a/src/app/utils/codeExport.test.js
+++ b/src/app/utils/codeExport.test.js
@@ -100,7 +100,7 @@ describe('buildCodeZip — engine sources', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getCodeZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(21)
+    expect(engineFiles).toHaveLength(22)
   })
 
   it('ZIP contains engine/SceneManager.js', async () => {

--- a/src/app/utils/engineSources.js
+++ b/src/app/utils/engineSources.js
@@ -15,6 +15,7 @@ import BaseRendererSrc from '../../engine/renderers/BaseRenderer.js?raw'
 import BitmapRendererSrc from '../../engine/renderers/BitmapRenderer.js?raw'
 import PixelArtRendererSrc from '../../engine/renderers/PixelArtRenderer.js?raw'
 import AsciiRendererSrc from '../../engine/renderers/AsciiRenderer.js?raw'
+import HalftoneRendererSrc from '../../engine/renderers/HalftoneRenderer.js?raw'
 import renderersIndexSrc from '../../engine/renderers/index.js?raw'
 import modelLoaderSrc from '../../engine/loaders/modelLoader.js?raw'
 import AnimationEngineSrc from '../../engine/animation/AnimationEngine.js?raw'
@@ -45,6 +46,7 @@ const ENGINE_SOURCES = [
   { path: 'engine/renderers/BitmapRenderer.js', content: BitmapRendererSrc },
   { path: 'engine/renderers/PixelArtRenderer.js', content: PixelArtRendererSrc },
   { path: 'engine/renderers/AsciiRenderer.js', content: AsciiRendererSrc },
+  { path: 'engine/renderers/HalftoneRenderer.js', content: HalftoneRendererSrc },
   { path: 'engine/renderers/index.js', content: renderersIndexSrc },
   { path: 'engine/loaders/modelLoader.js', content: modelLoaderSrc },
   { path: 'engine/animation/AnimationEngine.js', content: AnimationEngineSrc },

--- a/src/app/utils/engineSources.test.js
+++ b/src/app/utils/engineSources.test.js
@@ -18,6 +18,7 @@ const REQUIRED_PATHS = [
   'engine/renderers/BitmapRenderer.js',
   'engine/renderers/PixelArtRenderer.js',
   'engine/renderers/AsciiRenderer.js',
+  'engine/renderers/HalftoneRenderer.js',
   'engine/renderers/index.js',
   'engine/loaders/modelLoader.js',
   'engine/animation/AnimationEngine.js',
@@ -68,6 +69,7 @@ describe('ENGINE_SOURCES', () => {
       'engine/renderers/BitmapRenderer.js',
       'engine/renderers/PixelArtRenderer.js',
       'engine/renderers/AsciiRenderer.js',
+      'engine/renderers/HalftoneRenderer.js',
       'engine/renderers/index.js'
     ]
     const paths = new Set(ENGINE_SOURCES.map((e) => e.path))

--- a/src/app/utils/reactComponentExport.test.js
+++ b/src/app/utils/reactComponentExport.test.js
@@ -63,7 +63,7 @@ describe('buildReactComponent — ZIP structure', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(21)
+    expect(engineFiles).toHaveLength(22)
   })
 
   it('uses custom component name for folder', async () => {

--- a/src/app/utils/webComponentExport.test.js
+++ b/src/app/utils/webComponentExport.test.js
@@ -58,7 +58,7 @@ describe('buildWebComponent — ZIP structure', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(21)
+    expect(engineFiles).toHaveLength(22)
   })
 
   it('uses custom element name for folder and file', async () => {

--- a/src/engine/renderers/HalftoneRenderer.js
+++ b/src/engine/renderers/HalftoneRenderer.js
@@ -1,0 +1,202 @@
+import { BaseRenderer } from './BaseRenderer.js'
+
+const DEG2RAD = Math.PI / 180
+
+/**
+ * HalftoneRenderer — halftone dot grid renderer.
+ *
+ * Simulates the classic halftone printing/screen technique: each grid cell is
+ * filled with a dot whose radius scales with darkness (dark pixel → large dot,
+ * bright pixel → small/no dot). The color of each dot comes from the active
+ * palette via getColor(brightness).
+ *
+ * Dot shape: circle (standard) or diamond (rotated square, different texture).
+ *
+ * Angle rotation: the entire dot grid is rotated once per frame by applying a
+ * canvas-level transform (translate-rotate-restore). drawPixel() applies the
+ * same rotation math to particle coordinates so fade animations stay aligned.
+ */
+class HalftoneRenderer extends BaseRenderer {
+  constructor(options = {}) {
+    super({
+      pixelSize: 6,
+      minBrightness: 0.05,
+      invert: false,
+      backgroundColor: 'transparent',
+      halftoneDotShape: 'circle', // 'circle' | 'diamond'
+      halftoneAngle: 0, // degrees, normalized to [0, 180) on use
+      ...options
+    })
+    this._bitmapCanvas = document.createElement('canvas')
+    this._bitmapCanvas.style.display = 'block'
+    this._bitmapCtx = this._bitmapCanvas.getContext('2d')
+  }
+
+  get canvas() {
+    return this._bitmapCanvas
+  }
+
+  init(width, height) {
+    this.setSize(width, height)
+  }
+
+  setSize(width, height) {
+    if (this._bitmapCanvas) {
+      this._bitmapCanvas.width = Math.max(1, Math.floor(width))
+      this._bitmapCanvas.height = Math.max(1, Math.floor(height))
+    }
+  }
+
+  beginFrame(backgroundColor) {
+    if (!this._bitmapCtx) return
+    if (backgroundColor !== 'transparent') {
+      this._bitmapCtx.fillStyle = backgroundColor
+      this._bitmapCtx.fillRect(0, 0, this._bitmapCanvas.width, this._bitmapCanvas.height)
+    } else {
+      this._bitmapCtx.clearRect(0, 0, this._bitmapCanvas.width, this._bitmapCanvas.height)
+    }
+  }
+
+  endFrame() {}
+
+  shouldDraw(brightness) {
+    return brightness > (this.options.minBrightness ?? 0.05)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Draw a circle or diamond centered at (cx, cy) with given radius. */
+  _drawDot(ctx, cx, cy, radius) {
+    if (radius < 0.5) return
+    if (this.options.halftoneDotShape === 'diamond') {
+      ctx.save()
+      ctx.translate(cx, cy)
+      ctx.rotate(Math.PI / 4)
+      ctx.fillRect(-radius, -radius, radius * 2, radius * 2)
+      ctx.restore()
+    } else {
+      ctx.beginPath()
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }
+
+  /** Normalize angle to [0, 180) degrees and convert to radians. */
+  _normalizeRad(deg) {
+    return (((deg % 180) + 180) % 180) * DEG2RAD
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public render / drawPixel
+  // ---------------------------------------------------------------------------
+
+  render(imageData, gridW, gridH, getColor) {
+    const ctx = this._bitmapCtx
+    if (!ctx) return
+
+    const { pixelSize, minBrightness, invert, halftoneAngle } = this.options
+    const spacing = pixelSize
+    const maxRadius = spacing * 0.5 * 0.95
+    const rMin = 0.5
+    const angleRad = this._normalizeRad(halftoneAngle)
+
+    const rotated = angleRad !== 0
+    if (rotated) {
+      ctx.save()
+      ctx.translate(this._bitmapCanvas.width / 2, this._bitmapCanvas.height / 2)
+      ctx.rotate(angleRad)
+      ctx.translate(-this._bitmapCanvas.width / 2, -this._bitmapCanvas.height / 2)
+    }
+
+    let lastColor = null
+
+    for (let gy = 0; gy < gridH; gy++) {
+      for (let gx = 0; gx < gridW; gx++) {
+        const iOffset = (gy * gridW + gx) * 4
+        const r = imageData[iOffset]
+        const g = imageData[iOffset + 1]
+        const b = imageData[iOffset + 2]
+        const a = imageData[iOffset + 3]
+        if (a === 0) continue
+
+        const brightness = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+        if (brightness < minBrightness) continue
+
+        const adjusted = invert ? 1 - brightness : brightness
+        const rawRadius = (1 - adjusted) * maxRadius
+        if (rawRadius < rMin) continue // skip very bright (near-white) pixels
+        const radius = Math.min(maxRadius, rawRadius)
+
+        const cx = gx * spacing + spacing / 2
+        const cy = gy * spacing + spacing / 2
+
+        const color = getColor(adjusted)
+        if (color !== lastColor) {
+          ctx.fillStyle = color
+          lastColor = color
+        }
+
+        this._drawDot(ctx, cx, cy, radius)
+      }
+    }
+
+    if (rotated) ctx.restore()
+  }
+
+  /**
+   * Draw a single dot during fade animations.
+   * x/y arrive as (gx * pixelSize, gy * pixelSize) from BitmapEffect.initializeParticles.
+   * We recover the grid cell, compute the rotated dot center to match render(), and draw.
+   */
+  drawPixel(x, y, brightness, color, alpha = 1) {
+    const ctx = this._bitmapCtx
+    if (!ctx) return
+
+    const { pixelSize, halftoneAngle } = this.options
+    const spacing = pixelSize
+    const maxRadius = spacing * 0.5 * 0.95
+    const rMin = 0.5
+    const rawRadius = (1 - brightness) * maxRadius
+    if (rawRadius < rMin) return
+    const radius = Math.min(maxRadius, rawRadius)
+
+    // Recover unrotated grid-cell center
+    const gx = Math.round(x / pixelSize)
+    const gy = Math.round(y / pixelSize)
+    let cx = gx * spacing + spacing / 2
+    let cy = gy * spacing + spacing / 2
+
+    // Apply the same canvas rotation as render() so particles land on the rotated grid
+    if (halftoneAngle !== 0) {
+      const rad = this._normalizeRad(halftoneAngle)
+      const cosA = Math.cos(rad)
+      const sinA = Math.sin(rad)
+      const cw = this._bitmapCanvas.width
+      const ch = this._bitmapCanvas.height
+      const dx = cx - cw / 2
+      const dy = cy - ch / 2
+      cx = cw / 2 + dx * cosA - dy * sinA
+      cy = ch / 2 + dx * sinA + dy * cosA
+    }
+
+    const savedAlpha = ctx.globalAlpha
+    const savedFill = ctx.fillStyle
+    if (alpha < 1) ctx.globalAlpha = alpha
+    ctx.fillStyle = color
+    this._drawDot(ctx, cx, cy, radius)
+    ctx.globalAlpha = savedAlpha
+    ctx.fillStyle = savedFill
+  }
+
+  dispose() {
+    if (this._bitmapCanvas?.parentNode) {
+      this._bitmapCanvas.parentNode.removeChild(this._bitmapCanvas)
+    }
+    this._bitmapCanvas = null
+    this._bitmapCtx = null
+  }
+}
+
+export { HalftoneRenderer }

--- a/src/engine/renderers/HalftoneRenderer.test.js
+++ b/src/engine/renderers/HalftoneRenderer.test.js
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { HalftoneRenderer } from './HalftoneRenderer.js'
+
+// ---------------------------------------------------------------------------
+// Minimal canvas mock
+// ---------------------------------------------------------------------------
+
+function makeCtxMock() {
+  return {
+    fillStyle: '',
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    fillRect: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    _isMock: true
+  }
+}
+
+function makeCanvasMock(ctx) {
+  return {
+    width: 120,
+    height: 120,
+    style: {},
+    getContext: () => ctx,
+    parentNode: null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal 2×2 RGBA imageData (flat Uint8ClampedArray). */
+function makeImageData(r = 100, g = 100, b = 100, a = 255) {
+  const data = new Uint8ClampedArray(2 * 2 * 4)
+  for (let i = 0; i < 4; i++) {
+    data[i * 4] = r
+    data[i * 4 + 1] = g
+    data[i * 4 + 2] = b
+    data[i * 4 + 3] = a
+  }
+  return data
+}
+
+const getColor = () => '#ff0000'
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HalftoneRenderer — construction', () => {
+  it('creates a canvas and context on construction', () => {
+    const r = new HalftoneRenderer()
+    expect(r.canvas).toBeTruthy()
+    expect(r.canvas.tagName).toBe('CANVAS')
+  })
+
+  it('exposes default options', () => {
+    const r = new HalftoneRenderer()
+    expect(r.options.pixelSize).toBe(6)
+    expect(r.options.halftoneDotShape).toBe('circle')
+    expect(r.options.halftoneAngle).toBe(0)
+  })
+
+  it('merges constructor options', () => {
+    const r = new HalftoneRenderer({ halftoneDotShape: 'diamond', halftoneAngle: 45 })
+    expect(r.options.halftoneDotShape).toBe('diamond')
+    expect(r.options.halftoneAngle).toBe(45)
+  })
+})
+
+describe('HalftoneRenderer — setSize / init', () => {
+  it('setSize updates canvas dimensions', () => {
+    const r = new HalftoneRenderer()
+    r.setSize(200, 150)
+    expect(r.canvas.width).toBe(200)
+    expect(r.canvas.height).toBe(150)
+  })
+
+  it('init calls setSize', () => {
+    const r = new HalftoneRenderer()
+    r.init(100, 80)
+    expect(r.canvas.width).toBe(100)
+    expect(r.canvas.height).toBe(80)
+  })
+})
+
+describe('HalftoneRenderer — beginFrame', () => {
+  let ctx, r
+
+  beforeEach(() => {
+    ctx = makeCtxMock()
+    r = new HalftoneRenderer({ backgroundColor: '#000000' })
+    // Inject mock ctx
+    r._bitmapCtx = ctx
+    r._bitmapCanvas = makeCanvasMock(ctx)
+  })
+
+  it('fills background when color is not transparent', () => {
+    r.beginFrame('#000000')
+    expect(ctx.fillRect).toHaveBeenCalled()
+  })
+
+  it('clears when transparent', () => {
+    r.beginFrame('transparent')
+    expect(ctx.clearRect).toHaveBeenCalled()
+    expect(ctx.fillRect).not.toHaveBeenCalled()
+  })
+})
+
+describe('HalftoneRenderer — render (normal mode)', () => {
+  let ctx, r
+
+  beforeEach(() => {
+    ctx = makeCtxMock()
+    r = new HalftoneRenderer({ pixelSize: 6 })
+    r._bitmapCtx = ctx
+    r._bitmapCanvas = makeCanvasMock(ctx)
+  })
+
+  it('draws at least one dot for mid-gray input', () => {
+    const imageData = makeImageData(128, 128, 128)
+    r.render(imageData, 2, 2, getColor)
+    // A circle dot calls beginPath + arc + fill
+    expect(ctx.arc).toHaveBeenCalled()
+    expect(ctx.fill).toHaveBeenCalled()
+  })
+
+  it('skips fully transparent pixels (a=0)', () => {
+    const imageData = makeImageData(128, 128, 128, 0)
+    r.render(imageData, 2, 2, getColor)
+    expect(ctx.arc).not.toHaveBeenCalled()
+  })
+
+  it('skips pixels below minBrightness', () => {
+    const imageData = makeImageData(5, 5, 5) // very dark, brightness ≈ 0.02
+    r.render(imageData, 2, 2, getColor)
+    expect(ctx.arc).not.toHaveBeenCalled()
+  })
+
+  it('draws diamond shape with fillRect', () => {
+    r.updateOptions({ halftoneDotShape: 'diamond' })
+    const imageData = makeImageData(128, 128, 128)
+    r.render(imageData, 2, 2, getColor)
+    expect(ctx.fillRect).toHaveBeenCalled()
+  })
+
+  it('applies canvas rotation when halftoneAngle != 0', () => {
+    r.updateOptions({ halftoneAngle: 45 })
+    const imageData = makeImageData(128, 128, 128)
+    r.render(imageData, 2, 2, getColor)
+    expect(ctx.rotate).toHaveBeenCalled()
+  })
+
+  it('does not rotate when halftoneAngle is 0', () => {
+    r.updateOptions({ halftoneAngle: 0 })
+    const imageData = makeImageData(128, 128, 128)
+    r.render(imageData, 2, 2, getColor)
+    expect(ctx.rotate).not.toHaveBeenCalled()
+  })
+})
+
+describe('HalftoneRenderer — drawPixel', () => {
+  let ctx, r
+
+  beforeEach(() => {
+    ctx = makeCtxMock()
+    r = new HalftoneRenderer({ pixelSize: 6 })
+    r._bitmapCtx = ctx
+    r._bitmapCanvas = makeCanvasMock(ctx)
+  })
+
+  it('draws a dot for mid-brightness', () => {
+    r.drawPixel(0, 0, 0.5, '#00ff00', 1)
+    expect(ctx.arc).toHaveBeenCalled()
+    expect(ctx.fill).toHaveBeenCalled()
+  })
+
+  it('respects alpha — sets globalAlpha when alpha < 1', () => {
+    const alphaValues = []
+    Object.defineProperty(ctx, 'globalAlpha', {
+      get: () => alphaValues[alphaValues.length - 1] ?? 1,
+      set: (v) => {
+        alphaValues.push(v)
+      }
+    })
+    r.drawPixel(0, 0, 0.5, '#ff0000', 0.5)
+    expect(alphaValues).toContain(0.5)
+  })
+
+  it('restores globalAlpha and fillStyle after drawing', () => {
+    ctx.globalAlpha = 1
+    ctx.fillStyle = '#initial'
+    r.drawPixel(0, 0, 0.5, '#abcdef', 0.5)
+    expect(ctx.globalAlpha).toBe(1)
+    expect(ctx.fillStyle).toBe('#initial')
+  })
+
+  it('skips dots with near-zero brightness radius', () => {
+    // brightness ≈ 1 → radius ≈ 0 → skipped
+    r.drawPixel(0, 0, 0.999, '#fff', 1)
+    expect(ctx.arc).not.toHaveBeenCalled()
+  })
+})
+
+describe('HalftoneRenderer — shouldDraw', () => {
+  it('returns false below minBrightness', () => {
+    const r = new HalftoneRenderer({ minBrightness: 0.1 })
+    expect(r.shouldDraw(0.05)).toBe(false)
+  })
+
+  it('returns true above minBrightness', () => {
+    const r = new HalftoneRenderer({ minBrightness: 0.05 })
+    expect(r.shouldDraw(0.5)).toBe(true)
+  })
+})
+
+describe('HalftoneRenderer — dispose', () => {
+  it('removes canvas from DOM and nulls internal refs', () => {
+    const r = new HalftoneRenderer()
+    const mockParent = { removeChild: vi.fn() }
+    Object.defineProperty(r._bitmapCanvas, 'parentNode', { get: () => mockParent, configurable: true })
+    r.dispose()
+    expect(mockParent.removeChild).toHaveBeenCalled()
+    expect(r._bitmapCanvas).toBeNull()
+    expect(r._bitmapCtx).toBeNull()
+  })
+
+  it('is safe to call multiple times', () => {
+    const r = new HalftoneRenderer()
+    expect(() => {
+      r.dispose()
+      r.dispose()
+    }).not.toThrow()
+  })
+})
+
+describe('HalftoneRenderer — updateOptions', () => {
+  it('merges new options into existing', () => {
+    const r = new HalftoneRenderer({ pixelSize: 6 })
+    r.updateOptions({ halftoneAngle: 90, halftoneCmyk: true })
+    expect(r.options.halftoneAngle).toBe(90)
+    expect(r.options.halftoneCmyk).toBe(true)
+    expect(r.options.pixelSize).toBe(6) // unchanged
+  })
+})

--- a/src/engine/renderers/index.js
+++ b/src/engine/renderers/index.js
@@ -1,17 +1,20 @@
 import { BitmapRenderer } from './BitmapRenderer.js'
 import { PixelArtRenderer } from './PixelArtRenderer.js'
 import { AsciiRenderer } from './AsciiRenderer.js'
+import { HalftoneRenderer } from './HalftoneRenderer.js'
 
 const RENDERERS = {
   bitmap: BitmapRenderer,
   pixelArt: PixelArtRenderer,
-  ascii: AsciiRenderer
+  ascii: AsciiRenderer,
+  halftone: HalftoneRenderer
 }
 
 const RENDERER_LABELS = {
   bitmap: 'Bitmap (Dithered)',
   pixelArt: 'Pixel Art (Clean)',
-  ascii: 'ASCII Art'
+  ascii: 'ASCII Art',
+  halftone: 'Halftone'
 }
 
 /**

--- a/test/integration/exportConformance.test.js
+++ b/test/integration/exportConformance.test.js
@@ -218,7 +218,7 @@ describe('React component ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(21)
+    expect(engineFiles).toHaveLength(22)
   })
 })
 
@@ -254,7 +254,7 @@ describe('Web Component ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(21)
+    expect(engineFiles).toHaveLength(22)
   })
 })
 
@@ -324,6 +324,6 @@ describe('Code ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(21)
+    expect(engineFiles).toHaveLength(22)
   })
 })


### PR DESCRIPTION
## Summary

- Implements the **Halftone** rendering mode: each grid cell is drawn as a dot whose radius scales with darkness — dark pixels get large dots, bright pixels get small/no dots, producing a classic newspaper/pop-art look
- Dot shape: **Circle** (standard screen) or **Diamond** (rotated square, different texture)
- **Screen angle** slider (0–179°) rotates the entire dot grid via a single canvas-level transform per frame; fade animation particles apply the same rotation math so they stay aligned
- Wired into the existing pluggable renderer architecture — registered in `RENDERERS`/`RENDERER_LABELS`, options flow through the `unsubEffect` subscription in `PreviewCanvas`

## Changes

| File | What changed |
|---|---|
| `src/engine/renderers/HalftoneRenderer.js` | New renderer |
| `src/engine/renderers/HalftoneRenderer.test.js` | 22 unit tests |
| `src/engine/renderers/index.js` | Registered `halftone` |
| `src/app/store/useProjectStore.js` | `halftoneDotShape`, `halftoneAngle` state + setters (undoable) |
| `src/app/components/PreviewCanvas/PreviewCanvas.jsx` | Halftone fields added to effect subscription |
| `src/app/components/QualitySettings/QualitySettings.jsx` | `isHalftone` branch: Dot Spacing, Dot Shape, Screen Angle controls |
| `src/app/utils/engineSources.js` | `HalftoneRenderer` added to export manifest (22 entries) |
| 5 test files | Engine file count updated `21→22` |

## Test plan

- [x] All 292 tests pass (`npm test`)
- [x] `engineSources.js` manifest includes `HalftoneRenderer.js`
- [x] Manual: switch to Halftone mode in the UI, verify dots render correctly on a loaded model/shape
- [ ] Manual: verify screen angle slider rotates the grid visually
- [ ] Manual: verify fade animations (bloom/cascade) work with halftone active
- [ ] Manual: spot-check exports (APNG, GIF, sprite sheet) produce correct halftone frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)