### PR TITLE
feat: add Noise and Color Shift post-processing effects

### DIFF
--- a/src/app/components/PreviewCanvas/PreviewCanvas.jsx
+++ b/src/app/components/PreviewCanvas/PreviewCanvas.jsx
@@ -61,7 +61,13 @@ function PreviewCanvas() {
         scanlineGap: state.scanlineGap,
         scanlineOpacity: state.scanlineOpacity,
         chromaticAberration: state.chromaticAberration,
-        crtVignette: state.crtVignette
+        crtVignette: state.crtVignette,
+        noiseEnabled: state.noiseEnabled,
+        noiseAmount: state.noiseAmount,
+        noiseMonochrome: state.noiseMonochrome,
+        colorShiftEnabled: state.colorShiftEnabled,
+        colorShiftHue: state.colorShiftHue,
+        colorShiftSaturation: state.colorShiftSaturation
       }),
       (slice) => manager.updateEffectOptions(slice),
       { equalityFn: shallow }

--- a/src/app/components/QualitySettings/QualitySettings.jsx
+++ b/src/app/components/QualitySettings/QualitySettings.jsx
@@ -38,6 +38,18 @@ function QualitySettings() {
   const setChromaticAberration = useProjectStore((state) => state.setChromaticAberration)
   const crtVignette = useProjectStore((state) => state.crtVignette)
   const setCrtVignette = useProjectStore((state) => state.setCrtVignette)
+  const noiseEnabled = useProjectStore((state) => state.noiseEnabled)
+  const setNoiseEnabled = useProjectStore((state) => state.setNoiseEnabled)
+  const noiseAmount = useProjectStore((state) => state.noiseAmount)
+  const setNoiseAmount = useProjectStore((state) => state.setNoiseAmount)
+  const noiseMonochrome = useProjectStore((state) => state.noiseMonochrome)
+  const setNoiseMonochrome = useProjectStore((state) => state.setNoiseMonochrome)
+  const colorShiftEnabled = useProjectStore((state) => state.colorShiftEnabled)
+  const setColorShiftEnabled = useProjectStore((state) => state.setColorShiftEnabled)
+  const colorShiftHue = useProjectStore((state) => state.colorShiftHue)
+  const setColorShiftHue = useProjectStore((state) => state.setColorShiftHue)
+  const colorShiftSaturation = useProjectStore((state) => state.colorShiftSaturation)
+  const setColorShiftSaturation = useProjectStore((state) => state.setColorShiftSaturation)
   const backgroundColor = useProjectStore((state) => state.backgroundColor)
   const seed = useProjectStore((state) => state.seed)
   const setPixelSize = useProjectStore((state) => state.setPixelSize)
@@ -495,6 +507,87 @@ function QualitySettings() {
                 step="0.05"
                 value={crtVignette}
                 onChange={(e) => setCrtVignette(Number(e.target.value))}
+                className="w-full"
+              />
+            </>
+          )}
+
+          {/* ── Noise / Grain ── */}
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={noiseEnabled} onChange={(e) => setNoiseEnabled(e.target.checked)} />
+            Noise / Grain
+            <InfoTooltip content="Adds random film grain noise on top of the rendered frame." />
+          </label>
+
+          {noiseEnabled && (
+            <>
+              <label htmlFor="quality-noise-amount" className="flex items-center text-sm">
+                Amount: {noiseAmount.toFixed(2)}
+                <InfoTooltip content="Strength of the noise effect. Higher = more grain." />
+              </label>
+              <input
+                id="quality-noise-amount"
+                type="range"
+                min="0"
+                max="0.5"
+                step="0.01"
+                value={noiseAmount}
+                onChange={(e) => setNoiseAmount(Number(e.target.value))}
+                className="w-full"
+              />
+
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={noiseMonochrome}
+                  onChange={(e) => setNoiseMonochrome(e.target.checked)}
+                />
+                Monochrome
+                <InfoTooltip content="When on, grain is grayscale (same offset for R/G/B). When off, each channel gets independent noise (color grain)." />
+              </label>
+            </>
+          )}
+
+          {/* ── Color Shift ── */}
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={colorShiftEnabled}
+              onChange={(e) => setColorShiftEnabled(e.target.checked)}
+            />
+            Color Shift
+            <InfoTooltip content="Rotates the hue and adjusts saturation of the entire frame." />
+          </label>
+
+          {colorShiftEnabled && (
+            <>
+              <label htmlFor="quality-color-hue" className="flex items-center text-sm">
+                Hue: {colorShiftHue}°
+                <InfoTooltip content="Rotates all colors around the color wheel by the specified degrees." />
+              </label>
+              <input
+                id="quality-color-hue"
+                type="range"
+                min="0"
+                max="360"
+                step="1"
+                value={colorShiftHue}
+                onChange={(e) => setColorShiftHue(Number(e.target.value))}
+                className="w-full"
+              />
+
+              <label htmlFor="quality-color-saturation" className="flex items-center text-sm">
+                Saturation: {colorShiftSaturation.toFixed(2)}
+                <InfoTooltip content="Multiplies saturation. 0 = grayscale, 1 = unchanged, 2 = highly saturated." />
+              </label>
+              <input
+                id="quality-color-saturation"
+                type="range"
+                min="0"
+                max="2"
+                step="0.01"
+                value={colorShiftSaturation}
+                onChange={(e) => setColorShiftSaturation(Number(e.target.value))}
                 className="w-full"
               />
             </>

--- a/src/app/store/useProjectStore.js
+++ b/src/app/store/useProjectStore.js
@@ -49,6 +49,14 @@ const DEFAULT_STATE = {
   scanlineOpacity: 0.4, // darkness of scanline bands (0.1–0.8)
   chromaticAberration: 0, // R/B channel pixel shift (0–5)
   crtVignette: 0.3, // vignette corner strength (0–1)
+  // Noise/grain post-processing effect settings
+  noiseEnabled: false,
+  noiseAmount: 0.15, // grain strength (0–0.5)
+  noiseMonochrome: true, // same offset for R, G, B
+  // Color shift post-processing effect settings
+  colorShiftEnabled: false,
+  colorShiftHue: 0, // hue rotation in degrees (0–360)
+  colorShiftSaturation: 1.0, // saturation multiplier (0–2)
   // Input source type — which tab is active in the input panel
   inputType: 'model', // 'model' | 'shape' | 'text' | 'image'
   // Shape primitive settings
@@ -179,6 +187,13 @@ const useProjectStore = create(
       setScanlineOpacity: (scanlineOpacity) => set({ scanlineOpacity: clamp(scanlineOpacity, 0.1, 0.8) }),
       setChromaticAberration: (chromaticAberration) => set({ chromaticAberration: clamp(chromaticAberration, 0, 5) }),
       setCrtVignette: (crtVignette) => set({ crtVignette: clamp(crtVignette, 0, 1) }),
+      setNoiseEnabled: (noiseEnabled) => set({ noiseEnabled }),
+      setNoiseAmount: (noiseAmount) => set({ noiseAmount: clamp(noiseAmount, 0, 0.5) }),
+      setNoiseMonochrome: (noiseMonochrome) => set({ noiseMonochrome }),
+      setColorShiftEnabled: (colorShiftEnabled) => set({ colorShiftEnabled }),
+      setColorShiftHue: (colorShiftHue) => set({ colorShiftHue: clamp(colorShiftHue, 0, 360) }),
+      setColorShiftSaturation: (colorShiftSaturation) =>
+        set({ colorShiftSaturation: clamp(colorShiftSaturation, 0, 2) }),
       setInputType: (inputType) => set({ inputType }),
       setShapeType: (shapeType) => set({ shapeType, shapeParams: {} }),
       setShapeParam: (key, value) => set((state) => ({ shapeParams: { ...state.shapeParams, [key]: value } })),

--- a/src/app/utils/codeExport.test.js
+++ b/src/app/utils/codeExport.test.js
@@ -100,7 +100,7 @@ describe('buildCodeZip — engine sources', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getCodeZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(26)
+    expect(engineFiles).toHaveLength(28)
   })
 
   it('ZIP contains engine/SceneManager.js', async () => {

--- a/src/app/utils/engineSources.js
+++ b/src/app/utils/engineSources.js
@@ -26,6 +26,8 @@ import effectTypesSrc from '../../engine/animation/effectTypes.js?raw'
 import seededRandomSrc from '../../engine/utils/seededRandom.js?raw'
 import PostProcessingChainSrc from '../../engine/postprocessing/PostProcessingChain.js?raw'
 import CrtEffectSrc from '../../engine/postprocessing/effects/CrtEffect.js?raw'
+import NoiseEffectSrc from '../../engine/postprocessing/effects/NoiseEffect.js?raw'
+import ColorShiftEffectSrc from '../../engine/postprocessing/effects/ColorShiftEffect.js?raw'
 
 // Each entry: { path, content }
 // path is relative to whatever root folder the consumer creates (e.g. 'engine/SceneManager.js')
@@ -34,7 +36,7 @@ import CrtEffectSrc from '../../engine/postprocessing/effects/CrtEffect.js?raw'
 //   engine/effects/BitmapEffect.js, engine/effects/ditherStrategies.js,
 //   engine/effects/fadeVariants/*, engine/renderers/*, engine/loaders/modelLoader.js,
 //   engine/animation/*, engine/utils/seededRandom.js,
-//   engine/postprocessing/PostProcessingChain.js, engine/postprocessing/effects/CrtEffect.js
+//   engine/postprocessing/PostProcessingChain.js, engine/postprocessing/effects/*
 const ENGINE_SOURCES = [
   { path: 'engine/index.js', content: engineIndexSrc },
   { path: 'engine/SceneManager.js', content: SceneManagerSrc },
@@ -61,7 +63,9 @@ const ENGINE_SOURCES = [
   { path: 'engine/animation/effectTypes.js', content: effectTypesSrc },
   { path: 'engine/utils/seededRandom.js', content: seededRandomSrc },
   { path: 'engine/postprocessing/PostProcessingChain.js', content: PostProcessingChainSrc },
-  { path: 'engine/postprocessing/effects/CrtEffect.js', content: CrtEffectSrc }
+  { path: 'engine/postprocessing/effects/CrtEffect.js', content: CrtEffectSrc },
+  { path: 'engine/postprocessing/effects/NoiseEffect.js', content: NoiseEffectSrc },
+  { path: 'engine/postprocessing/effects/ColorShiftEffect.js', content: ColorShiftEffectSrc }
 ]
 
 export { ENGINE_SOURCES }

--- a/src/app/utils/engineSources.test.js
+++ b/src/app/utils/engineSources.test.js
@@ -28,7 +28,9 @@ const REQUIRED_PATHS = [
   'engine/animation/effectTypes.js',
   'engine/utils/seededRandom.js',
   'engine/postprocessing/PostProcessingChain.js',
-  'engine/postprocessing/effects/CrtEffect.js'
+  'engine/postprocessing/effects/CrtEffect.js',
+  'engine/postprocessing/effects/NoiseEffect.js',
+  'engine/postprocessing/effects/ColorShiftEffect.js'
 ]
 
 describe('ENGINE_SOURCES', () => {

--- a/src/app/utils/reactComponentExport.test.js
+++ b/src/app/utils/reactComponentExport.test.js
@@ -63,7 +63,7 @@ describe('buildReactComponent — ZIP structure', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(26)
+    expect(engineFiles).toHaveLength(28)
   })
 
   it('uses custom component name for folder', async () => {

--- a/src/app/utils/webComponentExport.test.js
+++ b/src/app/utils/webComponentExport.test.js
@@ -58,7 +58,7 @@ describe('buildWebComponent — ZIP structure', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(26)
+    expect(engineFiles).toHaveLength(28)
   })
 
   it('uses custom element name for folder and file', async () => {

--- a/src/engine/effects/BitmapEffect.js
+++ b/src/engine/effects/BitmapEffect.js
@@ -3,6 +3,8 @@ import { createFadeVariant } from './fadeVariants/index.js'
 import { BitmapRenderer } from '../renderers/BitmapRenderer.js'
 import { PostProcessingChain } from '../postprocessing/PostProcessingChain.js'
 import { CrtEffect } from '../postprocessing/effects/CrtEffect.js'
+import { NoiseEffect } from '../postprocessing/effects/NoiseEffect.js'
+import { ColorShiftEffect } from '../postprocessing/effects/ColorShiftEffect.js'
 
 class BitmapEffect extends BaseEffect {
   constructor(renderer, options = {}) {
@@ -42,6 +44,8 @@ class BitmapEffect extends BaseEffect {
     // Post-processing chain — effects applied after the renderer draws each frame
     this._postChain = new PostProcessingChain()
     this._postChain.addEffect('crt', new CrtEffect())
+    this._postChain.addEffect('noise', new NoiseEffect())
+    this._postChain.addEffect('colorShift', new ColorShiftEffect())
 
     // Active fade variant — recreated whenever options.fadeVariant changes.
     const initialVariant = this.options.fadeVariant ?? 'bloom'
@@ -170,8 +174,12 @@ class BitmapEffect extends BaseEffect {
     this._activeRenderer.endFrame()
 
     // Post-processing: applied after renderer draws, before next frame.
-    // CRT effect stacks on top of any render mode.
-    if (this.options.crtEnabled) {
+    // Update enabled state for each effect from current options.
+    this._postChain.setEnabled('crt', !!this.options.crtEnabled)
+    this._postChain.setEnabled('noise', !!this.options.noiseEnabled)
+    this._postChain.setEnabled('colorShift', !!this.options.colorShiftEnabled)
+
+    if (this._postChain.hasEnabledEffects()) {
       const ctx = this._activeRenderer.canvas?.getContext('2d')
       if (ctx) this._postChain.apply(ctx, this.width, this.height, this.options)
     }

--- a/src/engine/postprocessing/PostProcessingChain.js
+++ b/src/engine/postprocessing/PostProcessingChain.js
@@ -33,6 +33,14 @@ class PostProcessingChain {
   }
 
   /**
+   * Returns true if at least one registered effect is enabled.
+   * @returns {boolean}
+   */
+  hasEnabledEffects() {
+    return this._effects.some((e) => e.enabled)
+  }
+
+  /**
    * Apply all enabled effects in registration order.
    * @param {CanvasRenderingContext2D|null} ctx
    * @param {number} width

--- a/src/engine/postprocessing/effects/ColorShiftEffect.js
+++ b/src/engine/postprocessing/effects/ColorShiftEffect.js
@@ -1,0 +1,131 @@
+/**
+ * ColorShiftEffect — applies hue rotation and saturation shift as a post-processing pass.
+ *
+ * Prefers the native `ctx.filter` path (hue-rotate + saturate CSS filters) for
+ * performance. Falls back to manual RGB->HSL->RGB per-pixel conversion when
+ * `ctx.filter` is not supported.
+ *
+ * Set hue=0 and saturation=1.0 to skip entirely (no-op guard).
+ */
+class ColorShiftEffect {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.colorShiftHue=0] - hue rotation in degrees (0–360)
+   * @param {number} [opts.colorShiftSaturation=1.0] - saturation multiplier (0–2)
+   */
+  constructor({ colorShiftHue = 0, colorShiftSaturation = 1.0 } = {}) {
+    this.colorShiftHue = colorShiftHue
+    this.colorShiftSaturation = colorShiftSaturation
+  }
+
+  /**
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {number} width
+   * @param {number} height
+   * @param {object} params
+   * @param {number} [params.colorShiftHue]
+   * @param {number} [params.colorShiftSaturation]
+   */
+  apply(ctx, width, height, params) {
+    const hue = params.colorShiftHue ?? this.colorShiftHue
+    const saturation = params.colorShiftSaturation ?? this.colorShiftSaturation
+    if (hue === 0 && saturation === 1.0) return
+    if (!ctx || width <= 0 || height <= 0) return
+
+    const supportsFilter = typeof ctx.filter !== 'undefined'
+
+    if (supportsFilter) {
+      this._applyWithFilter(ctx, width, height, hue, saturation)
+    } else {
+      this._applyManual(ctx, width, height, hue, saturation)
+    }
+  }
+
+  /**
+   * Fast path — use CSS canvas filters.
+   */
+  _applyWithFilter(ctx, width, height, hue, saturation) {
+    // Save current canvas content to a temp canvas
+    const tempCanvas = document.createElement('canvas')
+    tempCanvas.width = width
+    tempCanvas.height = height
+    const tempCtx = tempCanvas.getContext('2d')
+    tempCtx.drawImage(ctx.canvas, 0, 0)
+
+    // Clear and redraw with filter
+    ctx.clearRect(0, 0, width, height)
+    ctx.filter = `hue-rotate(${hue}deg) saturate(${saturation})`
+    ctx.drawImage(tempCanvas, 0, 0)
+    ctx.filter = 'none'
+  }
+
+  /**
+   * Fallback — manual per-pixel RGB -> HSL -> RGB.
+   */
+  _applyManual(ctx, width, height, hue, saturation) {
+    const imageData = ctx.getImageData(0, 0, width, height)
+    const data = imageData.data
+    const hueShift = hue / 360
+
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i + 3] === 0) continue
+
+      const r = data[i] / 255
+      const g = data[i + 1] / 255
+      const b = data[i + 2] / 255
+
+      let [h, s, l] = rgbToHsl(r, g, b)
+      h = (h + hueShift) % 1
+      if (h < 0) h += 1
+      s = Math.max(0, Math.min(1, s * saturation))
+
+      const [nr, ng, nb] = hslToRgb(h, s, l)
+      data[i] = Math.round(nr * 255)
+      data[i + 1] = Math.round(ng * 255)
+      data[i + 2] = Math.round(nb * 255)
+    }
+
+    ctx.putImageData(imageData, 0, 0)
+  }
+}
+
+/**
+ * Convert RGB [0,1] to HSL [0,1].
+ */
+function rgbToHsl(r, g, b) {
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l]
+
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+  else if (max === g) h = ((b - r) / d + 2) / 6
+  else h = ((r - g) / d + 4) / 6
+
+  return [h, s, l]
+}
+
+/**
+ * Convert HSL [0,1] to RGB [0,1].
+ */
+function hslToRgb(h, s, l) {
+  if (s === 0) return [l, l, l]
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  return [hue2rgb(p, q, h + 1 / 3), hue2rgb(p, q, h), hue2rgb(p, q, h - 1 / 3)]
+}
+
+function hue2rgb(p, q, t) {
+  if (t < 0) t += 1
+  if (t > 1) t -= 1
+  if (t < 1 / 6) return p + (q - p) * 6 * t
+  if (t < 1 / 2) return q
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+  return p
+}
+
+export { ColorShiftEffect, rgbToHsl, hslToRgb }

--- a/src/engine/postprocessing/effects/ColorShiftEffect.test.js
+++ b/src/engine/postprocessing/effects/ColorShiftEffect.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ColorShiftEffect, rgbToHsl, hslToRgb } from './ColorShiftEffect.js'
+
+function makeCtx(width, height, { r = 200, g = 100, b = 50 } = {}) {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = r
+    data[i + 1] = g
+    data[i + 2] = b
+    data[i + 3] = 255
+  }
+  const imageData = { data, width, height }
+  // Simulate a ctx WITHOUT filter support for the fallback path
+  return {
+    getImageData: vi.fn(() => imageData),
+    putImageData: vi.fn(),
+    _imageData: imageData
+  }
+}
+
+function makeFilterCtx(width, height) {
+  const canvas = { width, height }
+  const drawn = []
+  const ctx = {
+    canvas,
+    filter: 'none',
+    clearRect: vi.fn(),
+    drawImage: vi.fn((...args) => drawn.push(args)),
+    _drawn: drawn
+  }
+  return ctx
+}
+
+describe('ColorShiftEffect', () => {
+  it('is a no-op when hue=0 and saturation=1.0', () => {
+    const effect = new ColorShiftEffect()
+    const ctx = makeCtx(4, 4)
+    const original = new Uint8ClampedArray(ctx._imageData.data)
+
+    effect.apply(ctx, 4, 4, { colorShiftHue: 0, colorShiftSaturation: 1.0 })
+
+    expect(ctx.getImageData).not.toHaveBeenCalled()
+    expect(ctx.putImageData).not.toHaveBeenCalled()
+    expect(ctx._imageData.data).toEqual(original)
+  })
+
+  it('uses ctx.filter path when filter is supported', () => {
+    const effect = new ColorShiftEffect()
+    const ctx = makeFilterCtx(10, 10)
+
+    effect.apply(ctx, 10, 10, { colorShiftHue: 90, colorShiftSaturation: 1.5 })
+
+    expect(ctx.clearRect).toHaveBeenCalled()
+    expect(ctx.filter).toBe('none') // reset after apply
+  })
+
+  it('uses manual fallback when ctx.filter is undefined', () => {
+    const effect = new ColorShiftEffect()
+    const ctx = makeCtx(4, 4, { r: 200, g: 100, b: 50 })
+    // Remove filter support
+    delete ctx.filter
+
+    const original = new Uint8ClampedArray(ctx._imageData.data)
+
+    effect.apply(ctx, 4, 4, { colorShiftHue: 180, colorShiftSaturation: 1.0 })
+
+    expect(ctx.getImageData).toHaveBeenCalledOnce()
+    expect(ctx.putImageData).toHaveBeenCalledOnce()
+
+    // Pixels should be modified
+    let changed = false
+    for (let i = 0; i < original.length; i++) {
+      if (ctx._imageData.data[i] !== original[i]) {
+        changed = true
+        break
+      }
+    }
+    expect(changed).toBe(true)
+  })
+
+  it('hue=360 is equivalent to hue=0 in manual path (full rotation)', () => {
+    const effect = new ColorShiftEffect()
+    const ctx = makeCtx(4, 4, { r: 200, g: 100, b: 50 })
+    delete ctx.filter
+    const original = new Uint8ClampedArray(ctx._imageData.data)
+
+    effect.apply(ctx, 4, 4, { colorShiftHue: 360, colorShiftSaturation: 1.0 })
+
+    // 360° rotation should return roughly the same colors (within rounding)
+    const data = ctx._imageData.data
+    for (let i = 0; i < data.length; i += 4) {
+      expect(Math.abs(data[i] - original[i])).toBeLessThanOrEqual(1)
+      expect(Math.abs(data[i + 1] - original[i + 1])).toBeLessThanOrEqual(1)
+      expect(Math.abs(data[i + 2] - original[i + 2])).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('saturation=0 desaturates to grayscale in manual path', () => {
+    const effect = new ColorShiftEffect()
+    const ctx = makeCtx(4, 4, { r: 200, g: 100, b: 50 })
+    delete ctx.filter
+
+    effect.apply(ctx, 4, 4, { colorShiftHue: 0, colorShiftSaturation: 0 })
+
+    const data = ctx._imageData.data
+    for (let i = 0; i < data.length; i += 4) {
+      // All channels should be equal (grayscale)
+      expect(data[i]).toBe(data[i + 1])
+      expect(data[i + 1]).toBe(data[i + 2])
+    }
+  })
+})
+
+describe('rgbToHsl / hslToRgb round-trip', () => {
+  it('round-trips pure red', () => {
+    const [h, s, l] = rgbToHsl(1, 0, 0)
+    const [r, g, b] = hslToRgb(h, s, l)
+    expect(r).toBeCloseTo(1, 4)
+    expect(g).toBeCloseTo(0, 4)
+    expect(b).toBeCloseTo(0, 4)
+  })
+
+  it('round-trips neutral gray', () => {
+    const [h, s, l] = rgbToHsl(0.5, 0.5, 0.5)
+    expect(s).toBe(0)
+    const [r, g, b] = hslToRgb(h, s, l)
+    expect(r).toBeCloseTo(0.5, 4)
+    expect(g).toBeCloseTo(0.5, 4)
+    expect(b).toBeCloseTo(0.5, 4)
+  })
+})

--- a/src/engine/postprocessing/effects/NoiseEffect.js
+++ b/src/engine/postprocessing/effects/NoiseEffect.js
@@ -1,0 +1,59 @@
+/**
+ * NoiseEffect — applies film grain as a post-processing pass.
+ *
+ * Per-pixel random brightness offset, optionally monochrome (same offset for
+ * R, G, B) or colored (independent per-channel offsets).
+ *
+ * Performance: uses getImageData + putImageData — ~width*height iterations.
+ * Set noiseAmount=0 to skip entirely.
+ */
+class NoiseEffect {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.noiseAmount=0.15] - strength 0–0.5
+   * @param {boolean} [opts.noiseMonochrome=true] - same offset for all channels
+   */
+  constructor({ noiseAmount = 0.15, noiseMonochrome = true } = {}) {
+    this.noiseAmount = noiseAmount
+    this.noiseMonochrome = noiseMonochrome
+  }
+
+  /**
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {number} width
+   * @param {number} height
+   * @param {object} params
+   * @param {number} [params.noiseAmount]
+   * @param {boolean} [params.noiseMonochrome]
+   */
+  apply(ctx, width, height, params) {
+    const amount = params.noiseAmount ?? this.noiseAmount
+    if (amount === 0) return
+    if (!ctx || width <= 0 || height <= 0) return
+
+    const mono = params.noiseMonochrome ?? this.noiseMonochrome
+    const imageData = ctx.getImageData(0, 0, width, height)
+    const data = imageData.data
+    const strength = amount * 255 * 2
+
+    for (let i = 0; i < data.length; i += 4) {
+      // Skip fully transparent pixels
+      if (data[i + 3] === 0) continue
+
+      if (mono) {
+        const offset = (Math.random() - 0.5) * strength
+        data[i] = Math.max(0, Math.min(255, data[i] + offset))
+        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + offset))
+        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + offset))
+      } else {
+        data[i] = Math.max(0, Math.min(255, data[i] + (Math.random() - 0.5) * strength))
+        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + (Math.random() - 0.5) * strength))
+        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + (Math.random() - 0.5) * strength))
+      }
+    }
+
+    ctx.putImageData(imageData, 0, 0)
+  }
+}
+
+export { NoiseEffect }

--- a/src/engine/postprocessing/effects/NoiseEffect.test.js
+++ b/src/engine/postprocessing/effects/NoiseEffect.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { NoiseEffect } from './NoiseEffect.js'
+
+function makeCtx(width, height, fillValue = 128) {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = fillValue
+    data[i + 1] = fillValue
+    data[i + 2] = fillValue
+    data[i + 3] = 255
+  }
+  const imageData = { data, width, height }
+  return {
+    getImageData: vi.fn(() => imageData),
+    putImageData: vi.fn(),
+    _imageData: imageData
+  }
+}
+
+describe('NoiseEffect', () => {
+  it('is a no-op when noiseAmount === 0', () => {
+    const effect = new NoiseEffect()
+    const ctx = makeCtx(4, 4)
+    const original = new Uint8ClampedArray(ctx._imageData.data)
+
+    effect.apply(ctx, 4, 4, { noiseAmount: 0, noiseMonochrome: true })
+
+    expect(ctx.getImageData).not.toHaveBeenCalled()
+    expect(ctx.putImageData).not.toHaveBeenCalled()
+    // Data unchanged
+    expect(ctx._imageData.data).toEqual(original)
+  })
+
+  it('mutates pixels when noiseAmount > 0', () => {
+    const effect = new NoiseEffect()
+    const ctx = makeCtx(8, 8)
+    const original = new Uint8ClampedArray(ctx._imageData.data)
+
+    effect.apply(ctx, 8, 8, { noiseAmount: 0.3, noiseMonochrome: true })
+
+    expect(ctx.getImageData).toHaveBeenCalledOnce()
+    expect(ctx.putImageData).toHaveBeenCalledOnce()
+    // At least some pixel should differ (extremely unlikely all random offsets are 0)
+    let changed = false
+    for (let i = 0; i < original.length; i++) {
+      if (ctx._imageData.data[i] !== original[i]) {
+        changed = true
+        break
+      }
+    }
+    expect(changed).toBe(true)
+  })
+
+  it('monochrome: R, G, B receive the same offset per pixel', () => {
+    const effect = new NoiseEffect()
+    const ctx = makeCtx(4, 4, 128)
+
+    effect.apply(ctx, 4, 4, { noiseAmount: 0.5, noiseMonochrome: true })
+
+    const data = ctx._imageData.data
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i + 3] === 0) continue
+      // R, G, B should have been shifted by the same offset from 128
+      const dr = data[i] - 128
+      const dg = data[i + 1] - 128
+      const db = data[i + 2] - 128
+      expect(dr).toBe(dg)
+      expect(dr).toBe(db)
+    }
+  })
+
+  it('colored: R, G, B have independent offsets', () => {
+    const effect = new NoiseEffect()
+    // Use a larger canvas for statistical confidence
+    const ctx = makeCtx(16, 16, 128)
+
+    effect.apply(ctx, 16, 16, { noiseAmount: 0.5, noiseMonochrome: false })
+
+    const data = ctx._imageData.data
+    let allSame = true
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i + 3] === 0) continue
+      const dr = data[i] - 128
+      const dg = data[i + 1] - 128
+      const db = data[i + 2] - 128
+      if (dr !== dg || dr !== db) {
+        allSame = false
+        break
+      }
+    }
+    // With 256 pixels and independent random offsets, the probability they're all
+    // identical is vanishingly small
+    expect(allSame).toBe(false)
+  })
+})

--- a/test/integration/exportConformance.test.js
+++ b/test/integration/exportConformance.test.js
@@ -219,7 +219,7 @@ describe('React component ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(26)
+    expect(engineFiles).toHaveLength(28)
   })
 })
 
@@ -255,7 +255,7 @@ describe('Web Component ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(26)
+    expect(engineFiles).toHaveLength(28)
   })
 })
 
@@ -325,7 +325,7 @@ describe('Code ZIP conformance', () => {
   it('ZIP contains 14 engine source files', async () => {
     const zip = await getZip()
     const engineFiles = Object.keys(zip.files).filter((p) => p.includes('/engine/') && !p.endsWith('/'))
-    expect(engineFiles).toHaveLength(26)
+    expect(engineFiles).toHaveLength(28)
   })
 })
 


### PR DESCRIPTION
## Summary
- Add NoiseEffect (film grain) with amount and monochrome controls
- Add ColorShiftEffect (hue/saturation) with feature-detected ctx.filter path + pixel fallback
- Wire both effects into PostProcessingChain via BitmapEffect
- Add hasEnabledEffects() to PostProcessingChain for efficient guard
- Add store fields, PreviewCanvas subscription, and QualitySettings UI controls
- Update engineSources.js manifest (26 → 28 entries)

## Test plan
- [ ] `npm test` passes including new NoiseEffect and ColorShiftEffect tests
- [ ] Toggle Noise on/off in UI, verify grain appears/disappears
- [ ] Toggle Color Shift, adjust hue/saturation, verify visual effect
- [ ] Verify stacking: CRT + Noise + Color Shift all active simultaneously
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core render/post-processing path and adds new `getImageData`/per-pixel operations that can impact performance or visual output across all render modes and exported artifacts.
> 
> **Overview**
> Adds two new post-processing effects—`NoiseEffect` (film grain) and `ColorShiftEffect` (hue rotation + saturation)—and wires them into `BitmapEffect`’s `PostProcessingChain` so they can stack with existing CRT processing.
> 
> Exposes the new controls end-to-end: new Zustand store fields/setters, `PreviewCanvas` option subscriptions, and `QualitySettings` UI toggles/sliders. Updates export manifests/tests to include the two new engine source files (engine sources count 26→28) and adds unit tests for both effects plus a small `PostProcessingChain.hasEnabledEffects()` guard to avoid unnecessary work when all effects are disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1017812361325ad1ddfea1231643e3c318392f97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->