### PR TITLE
feat: add orbit camera animation effect

### DIFF
--- a/src/app/components/AnimationControls/AnimationControls.jsx
+++ b/src/app/components/AnimationControls/AnimationControls.jsx
@@ -10,7 +10,8 @@ const EFFECT_LABELS = {
   float: 'Float',
   bounce: 'Bounce',
   pulse: 'Pulse',
-  shake: 'Shake'
+  shake: 'Shake',
+  orbit: 'Orbit'
 }
 
 function AnimationControls() {

--- a/src/engine/SceneManager.js
+++ b/src/engine/SceneManager.js
@@ -84,7 +84,7 @@ class SceneManager {
       const deltaSeconds = Math.max(0, Math.min((now - this.lastFrameTime) / 1000, 0.25))
       this.lastFrameTime = now
       if (this.hasLayers()) {
-        this.animationEngine.update(this.animGroup, this.effect, deltaSeconds)
+        this.animationEngine.update(this.animGroup, this.effect, deltaSeconds, this.camera)
       }
       this.effect.render(this.scene, this.camera)
       this._onFrameRendered?.()
@@ -463,7 +463,7 @@ class SceneManager {
    * @param {number} absoluteTimeMs
    */
   renderAtTime(absoluteTimeMs) {
-    this.animationEngine.seekTo(absoluteTimeMs, this.animGroup, this.effect)
+    this.animationEngine.seekTo(absoluteTimeMs, this.animGroup, this.effect, this.camera)
     this.renderOnce()
   }
 
@@ -488,6 +488,8 @@ class SceneManager {
     if (this.hasLayers()) {
       this.animGroup.rotation.set(0, 0, 0)
     }
+    this.camera.position.set(0, 0.5, 5)
+    this.camera.lookAt(0, 0, 0)
     if (this.animationEngine.useFadeInOut) {
       this.effect.startAnimation('fadeIn')
     } else {

--- a/src/engine/animation/AnimationEngine.js
+++ b/src/engine/animation/AnimationEngine.js
@@ -29,6 +29,10 @@ class AnimationEngine {
     // { startRotation: number, elapsed: number }
     this._resetTransitions = { x: null, y: null, z: null, positionY: null, scale: null }
 
+    // Orbit camera baseline — captured on first frame with orbit active.
+    this._orbitBaseline = null
+    this._orbitRestorePending = null
+
     // Snapshot of previous effects — populated on the first update() call so
     // startup never triggers a spurious reset.
     this._previousEffects = null
@@ -58,7 +62,7 @@ class AnimationEngine {
     this.baseRotation = { ...baseRot }
   }
 
-  applyEffects(modelGroup, deltaSeconds) {
+  applyEffects(modelGroup, deltaSeconds, camera) {
     if (!modelGroup) return
     const e = this.animationEffects
     const speed = this.speed * deltaSeconds
@@ -69,7 +73,7 @@ class AnimationEngine {
     if (e.spinZ && !this._resetTransitions.z) modelGroup.rotation.z += speed
 
     // Advance shared time for all time-dependent effects (once per frame)
-    if (e.float || e.bounce || e.pulse || e.shake) {
+    if (e.float || e.bounce || e.pulse || e.shake || e.orbit) {
       this.time += deltaSeconds
     }
 
@@ -93,6 +97,19 @@ class AnimationEngine {
       const rng = createRNG(shakeSeed)
       modelGroup.position.x = (rng() - 0.5) * 0.08
       modelGroup.position.z = (rng() - 0.5) * 0.08
+    }
+
+    if (e.orbit && camera) {
+      if (!this._orbitBaseline) {
+        this._orbitBaseline = {
+          pos: camera.position.clone(),
+          quat: camera.quaternion.clone()
+        }
+      }
+      const r = this._orbitBaseline.pos.length()
+      const angle = this.time * this.speed * 0.5
+      camera.position.set(Math.sin(angle) * r, this._orbitBaseline.pos.y, Math.cos(angle) * r)
+      camera.lookAt(0, 0, 0)
     }
   }
 
@@ -161,6 +178,15 @@ class AnimationEngine {
       modelGroup.position.x = 0
       modelGroup.position.z = 0
     }
+
+    // orbit: flag baseline for restoration on toggle-off (camera restore happens in update())
+    if (prev.orbit && !curr.orbit && this._orbitBaseline) {
+      this._orbitRestorePending = this._orbitBaseline
+      this._orbitBaseline = null
+    }
+    if (!prev.orbit && curr.orbit) {
+      this._orbitRestorePending = null
+    }
   }
 
   // Advance all active lerps and write corrected rotation values.
@@ -211,9 +237,10 @@ class AnimationEngine {
 
   _clearResetTransitions() {
     this._resetTransitions = { x: null, y: null, z: null, positionY: null, scale: null }
+    this._orbitRestorePending = null
   }
 
-  update(modelGroup, effect, deltaSeconds = 1 / 60) {
+  update(modelGroup, effect, deltaSeconds = 1 / 60, camera) {
     // Initialise the previous-effects snapshot on the very first frame so we
     // never trigger a spurious reset at startup.
     if (this._previousEffects === null) {
@@ -221,6 +248,14 @@ class AnimationEngine {
     }
 
     this._checkForResets(modelGroup)
+
+    // Restore camera from orbit baseline when orbit was just toggled off
+    if (this._orbitRestorePending && camera) {
+      camera.position.copy(this._orbitRestorePending.pos)
+      camera.quaternion.copy(this._orbitRestorePending.quat)
+      this._orbitRestorePending = null
+    }
+
     // Snapshot current state for the next frame — done after _checkForResets so
     // the comparison above always sees the transition that just happened.
     this._previousEffects = { ...this.animationEffects }
@@ -229,7 +264,7 @@ class AnimationEngine {
       if (effect.getAnimationPhase() !== 'show') {
         effect.startAnimation('show')
       }
-      this.applyEffects(modelGroup, deltaSeconds)
+      this.applyEffects(modelGroup, deltaSeconds, camera)
       this._applyResetTransitions(modelGroup, deltaSeconds)
       return
     }
@@ -244,7 +279,7 @@ class AnimationEngine {
       // tilt as the static render snaps to a different pose than the particle positions.
       // Rotation begins on the next frame when the show branch runs normally.
     } else if (currentPhase === 'show') {
-      this.applyEffects(modelGroup, deltaSeconds)
+      this.applyEffects(modelGroup, deltaSeconds, camera)
       this._applyResetTransitions(modelGroup, deltaSeconds)
       if (now - this.phaseStartTime >= this.showPhaseDuration) {
         effect.startAnimation('fadeOut')
@@ -252,7 +287,7 @@ class AnimationEngine {
     } else if (currentPhase === 'fadeOut') {
       // Continue rotating during fade-out — particles are 2D snapshots that fade
       // independently of the 3D model, so rotation here is visually seamless.
-      this.applyEffects(modelGroup, deltaSeconds)
+      this.applyEffects(modelGroup, deltaSeconds, camera)
       this._applyResetTransitions(modelGroup, deltaSeconds)
       if (effect.isAnimationComplete()) {
         effect.startAnimation('fadeIn')
@@ -271,12 +306,13 @@ class AnimationEngine {
     this.time = 0
     this.phaseStartTime = 0
     this._clearResetTransitions()
+    this._orbitBaseline = null
   }
 
   // Apply the animation state for an absolute position within the loop.
   // Sets model rotation from t=0 and configures effect phase/progress.
   // Safe to call with a paused renderer loop.
-  seekTo(absoluteTimeMs, modelGroup, effect) {
+  seekTo(absoluteTimeMs, modelGroup, effect, camera) {
     // Clear any in-progress resets — they're incompatible with deterministic seeking.
     this._clearResetTransitions()
 
@@ -334,6 +370,15 @@ class AnimationEngine {
         modelGroup.position.x = (rng() - 0.5) * 0.08
         modelGroup.position.z = (rng() - 0.5) * 0.08
       }
+    }
+
+    if (this.animationEffects.orbit && camera) {
+      const showTs = absoluteTimeMs / 1000
+      const r = this._orbitBaseline ? this._orbitBaseline.pos.length() : 5
+      const baseY = this._orbitBaseline ? this._orbitBaseline.pos.y : 0.5
+      const angle = showTs * this.speed * 0.5
+      camera.position.set(Math.sin(angle) * r, baseY, Math.cos(angle) * r)
+      camera.lookAt(0, 0, 0)
     }
 
     if (effect) {

--- a/src/engine/animation/AnimationEngine.test.js
+++ b/src/engine/animation/AnimationEngine.test.js
@@ -71,6 +71,7 @@ describe('AnimationEngine', () => {
     expect(engine.animationEffects.bounce).toBe(false)
     expect(engine.animationEffects.pulse).toBe(false)
     expect(engine.animationEffects.shake).toBe(false)
+    expect(engine.animationEffects.orbit).toBe(false)
   })
 })
 
@@ -202,5 +203,139 @@ describe('AnimationEngine — seekTo with new effects', () => {
     engine.seekTo(3000, g2, null)
     expect(g1.position.x).toBe(g2.position.x)
     expect(g1.position.z).toBe(g2.position.z)
+  })
+})
+
+function makeCamera(x = 0, y = 0.5, z = 5) {
+  return {
+    position: {
+      x,
+      y,
+      z,
+      clone() {
+        return {
+          x: this.x,
+          y: this.y,
+          z: this.z,
+          length() {
+            return Math.sqrt(this.x ** 2 + this.y ** 2 + this.z ** 2)
+          }
+        }
+      },
+      set(nx, ny, nz) {
+        this.x = nx
+        this.y = ny
+        this.z = nz
+      },
+      copy(v) {
+        this.x = v.x
+        this.y = v.y
+        this.z = v.z
+      },
+      length() {
+        return Math.sqrt(this.x ** 2 + this.y ** 2 + this.z ** 2)
+      }
+    },
+    quaternion: {
+      x: 0,
+      y: 0,
+      z: 0,
+      w: 1,
+      clone() {
+        return { x: this.x, y: this.y, z: this.z, w: this.w }
+      },
+      copy(q) {
+        this.x = q.x
+        this.y = q.y
+        this.z = q.z
+        this.w = q.w
+      }
+    },
+    lookAt() {}
+  }
+}
+
+describe('AnimationEngine — orbit', () => {
+  it('moves camera position when orbit is active', () => {
+    const engine = new AnimationEngine()
+    engine.animationEffects = { ...DEFAULT_ANIMATION_EFFECTS, spinY: false, orbit: true }
+    const group = makeFullGroup()
+    const camera = makeCamera()
+    const origZ = camera.position.z
+    engine.applyEffects(group, 0.5, camera)
+    const moved = camera.position.x !== 0 || camera.position.z !== origZ
+    expect(moved).toBe(true)
+  })
+
+  it('is a no-op when camera is null', () => {
+    const engine = new AnimationEngine()
+    engine.animationEffects = { ...DEFAULT_ANIMATION_EFFECTS, spinY: false, orbit: true }
+    const group = makeFullGroup()
+    // Should not throw when camera is undefined
+    engine.applyEffects(group, 0.5)
+    expect(group.rotation.x).toBe(0)
+  })
+
+  it('produces identical camera pose for identical time in applyEffects vs seekTo', () => {
+    const engine = new AnimationEngine()
+    engine.useFadeInOut = false
+    engine.animationEffects = { ...DEFAULT_ANIMATION_EFFECTS, spinY: false, orbit: true }
+
+    // Use applyEffects to advance to a known time
+    const cam1 = makeCamera()
+    const group1 = makeFullGroup()
+    engine.applyEffects(group1, 2.0, cam1)
+    const pos1 = { x: cam1.position.x, y: cam1.position.y, z: cam1.position.z }
+
+    // Use seekTo for the same absolute time (engine.time was set to 2.0 by applyEffects)
+    const cam2 = makeCamera()
+    const group2 = makeFullGroup()
+    engine.seekTo(2000, group2, null, cam2)
+    const pos2 = { x: cam2.position.x, y: cam2.position.y, z: cam2.position.z }
+
+    expect(pos1.x).toBeCloseTo(pos2.x, 5)
+    expect(pos1.y).toBeCloseTo(pos2.y, 5)
+    expect(pos1.z).toBeCloseTo(pos2.z, 5)
+  })
+
+  it('restores camera to baseline when orbit is toggled off', () => {
+    const engine = new AnimationEngine()
+    engine.animationEffects = { ...DEFAULT_ANIMATION_EFFECTS, orbit: true }
+    engine._previousEffects = { ...engine.animationEffects }
+
+    const group = makeFullGroup()
+    const camera = makeCamera(0, 0.5, 5)
+
+    // Apply orbit to capture baseline and move camera
+    engine.applyEffects(group, 1.0, camera)
+    expect(engine._orbitBaseline).not.toBeNull()
+
+    // Toggle orbit off
+    engine.animationEffects = { ...DEFAULT_ANIMATION_EFFECTS, orbit: false }
+
+    const mockEffect = {
+      getAnimationPhase: () => 'show',
+      isAnimationComplete: () => false,
+      startAnimation: () => {},
+      setPhaseProgress: () => {}
+    }
+    engine.update(group, mockEffect, 1 / 60, camera)
+
+    // Camera should be restored to baseline
+    expect(camera.position.x).toBeCloseTo(0, 5)
+    expect(camera.position.y).toBeCloseTo(0.5, 5)
+    expect(camera.position.z).toBeCloseTo(5, 5)
+  })
+
+  it('does not interfere with modelGroup rotation animations', () => {
+    const engine = new AnimationEngine()
+    engine.animationEffects = { ...DEFAULT_ANIMATION_EFFECTS, spinY: true, orbit: true }
+    const group = makeFullGroup()
+    const camera = makeCamera()
+    engine.applyEffects(group, 0.5, camera)
+    // spinY should still rotate the model
+    expect(group.rotation.y).not.toBe(0)
+    // orbit should move the camera
+    expect(camera.position.x !== 0 || camera.position.z !== 5).toBe(true)
   })
 })

--- a/src/engine/animation/effectTypes.js
+++ b/src/engine/animation/effectTypes.js
@@ -22,7 +22,8 @@ const DEFAULT_ANIMATION_EFFECTS = Object.freeze({
   float: false,
   bounce: false,
   pulse: false,
-  shake: false
+  shake: false,
+  orbit: false
 })
 
 /** @type {ReadonlyArray<string>} */

--- a/src/engine/animation/effectTypes.test.js
+++ b/src/engine/animation/effectTypes.test.js
@@ -4,7 +4,7 @@ import { ANIMATION_EFFECT_KEYS, DEFAULT_ANIMATION_EFFECTS } from './effectTypes.
 describe('effectTypes', () => {
   it('ANIMATION_EFFECT_KEYS contains all expected effects', () => {
     expect(Array.isArray(ANIMATION_EFFECT_KEYS)).toBe(true)
-    expect(ANIMATION_EFFECT_KEYS).toHaveLength(7)
+    expect(ANIMATION_EFFECT_KEYS).toHaveLength(8)
     expect(ANIMATION_EFFECT_KEYS).toContain('spinX')
     expect(ANIMATION_EFFECT_KEYS).toContain('spinY')
     expect(ANIMATION_EFFECT_KEYS).toContain('spinZ')
@@ -12,6 +12,7 @@ describe('effectTypes', () => {
     expect(ANIMATION_EFFECT_KEYS).toContain('bounce')
     expect(ANIMATION_EFFECT_KEYS).toContain('pulse')
     expect(ANIMATION_EFFECT_KEYS).toContain('shake')
+    expect(ANIMATION_EFFECT_KEYS).toContain('orbit')
   })
 
   it('DEFAULT_ANIMATION_EFFECTS has spinY=true and rest false', () => {
@@ -22,6 +23,7 @@ describe('effectTypes', () => {
     expect(DEFAULT_ANIMATION_EFFECTS.bounce).toBe(false)
     expect(DEFAULT_ANIMATION_EFFECTS.pulse).toBe(false)
     expect(DEFAULT_ANIMATION_EFFECTS.shake).toBe(false)
+    expect(DEFAULT_ANIMATION_EFFECTS.orbit).toBe(false)
   })
 
   it('both are frozen', () => {


### PR DESCRIPTION
## Summary
- Add 'orbit' effect to effectTypes (7 → 8 effects)
- Implement camera orbit in AnimationEngine: captures baseline on first frame, orbits at configurable speed, restores on toggle-off
- Thread camera parameter through SceneManager update/seekTo calls
- Add Orbit label to AnimationControls UI
- seekTo() supports analytical orbit reconstruction for accurate export frame seeking

## Test plan
- [ ] `npm test` passes including new orbit tests
- [ ] Toggle Orbit in UI, verify camera circles the model
- [ ] Toggle Orbit off, verify camera returns to original position
- [ ] Export APNG with Orbit enabled — verify orbit in exported frames
- [ ] Orbit + spinY simultaneously — verify no interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)